### PR TITLE
Implement CLI argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,8 @@ dependencies = [
 name = "comenq-lib"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "comenq",
  "cucumber",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ serde_json = { workspace = true }
 [dev-dependencies]
 cucumber = "0.20"
 tokio = { workspace = true }
+clap = { workspace = true }
+comenq = { path = "crates/comenq" }
 
 [[test]]
 name = "cucumber"

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -3,6 +3,9 @@ name = "comenq"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/crates/comenq/src/lib.rs
+++ b/crates/comenq/src/lib.rs
@@ -1,0 +1,60 @@
+//! Library utilities for the `comenq` CLI.
+
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Command line arguments for the `comenq` client.
+#[derive(Debug, Parser)]
+#[command(name = "comenq", about = "Enqueue a GitHub PR comment")]
+pub struct Args {
+    /// The repository in 'owner/repo' format (e.g., "rust-lang/rust").
+    #[arg(value_parser = validate_repo_slug)]
+    pub repo_slug: String,
+
+    /// The pull request number to comment on.
+    pub pr_number: u64,
+
+    /// The body of the comment. It is recommended to quote this argument.
+    pub comment_body: String,
+
+    /// Path to the daemon's Unix Domain Socket.
+    #[arg(long, default_value = "/run/comenq/socket")]
+    pub socket: PathBuf,
+}
+
+fn validate_repo_slug(s: &str) -> Result<String, String> {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Ok(s.to_owned())
+    } else {
+        Err(String::from("invalid repository format, use 'owner/repo'"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+    use clap::Parser;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("octocat/hello-world", 1, "Hi")]
+    fn parses_valid_arguments(#[case] slug: &str, #[case] pr: u64, #[case] body: &str) {
+        let pr_str = pr.to_string();
+        let args = Args::try_parse_from(["comenq", slug, &pr_str, body]);
+        let args = args.expect("valid arguments should parse");
+        assert_eq!(args.repo_slug, slug);
+        assert_eq!(args.pr_number, pr);
+        assert_eq!(args.comment_body, body);
+    }
+
+    #[rstest]
+    #[case("octocat")]
+    #[case("/repo")]
+    #[case("owner/")]
+    #[case("owner/repo/extra")]
+    fn rejects_invalid_slug(#[case] slug: &str) {
+        let result = Args::try_parse_from(["comenq", slug, "1", "Hi"]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/comenq/src/main.rs
+++ b/crates/comenq/src/main.rs
@@ -5,6 +5,10 @@ use clap::Parser;
 use comenq::Args;
 
 fn main() {
-    let _args = Args::parse();
-    println!("Hello from Comenq!");
+    let args = Args::parse();
+    todo!(
+        "Connect to daemon at {} to enqueue comment for {}",
+        args.socket.display(),
+        args.repo_slug
+    );
 }

--- a/crates/comenq/src/main.rs
+++ b/crates/comenq/src/main.rs
@@ -1,3 +1,10 @@
+//! CLI client for the Comenq service.
+//! Parses user input and forwards it to the daemon.
+
+use clap::Parser;
+use comenq::Args;
+
 fn main() {
+    let _args = Args::parse();
     println!("Hello from Comenq!");
 }

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -284,6 +284,10 @@ async fn main() {
     let owner = parts[0].to_string();
     let repo = parts[1].to_string();
 
+    // Using a custom value parser keeps the error handling within `clap`
+    // itself, providing immediate feedback if the slug is malformed.
+
+
     // 3. Construct the request payload.
     let request = CommentRequest {
         owner,

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -164,7 +164,8 @@ self-documenting.[^10] The
 
 `#[arg(...)]` attributes provide fine-grained control over each argument, such
 as defining a `default_value` for the socket path, making the client flexible
-for different environments.[^3]
+for different environments. The optional `--socket` flag overrides this path
+when specified, giving users a simple way to adapt to custom deployments.[^3]
 
 ### 2.2. Client-Daemon IPC Protocol
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,10 +14,10 @@
 
 ## Milestone 2: `comenq` CLI Client
 
-- [ ] Implement the CLI argument parsing using `clap`'s derive macro to define
+- [x] Implement the CLI argument parsing using `clap`'s derive macro to define
   the `Args` struct (`repo_slug`, `pr_number`, `comment_body`, `socket`).
 
-- [ ] Add validation for the `owner/repo` slug format.
+- [x] Add validation for the `owner/repo` slug format.
 
 - [ ] Implement the client's `main` function to connect to the daemon's Unix
   Domain Socket using `tokio::net::UnixStream`.

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -4,6 +4,8 @@ use steps::{CliWorld, CommentWorld};
 
 #[tokio::main]
 async fn main() {
-    CommentWorld::run("tests/features/comment_request.feature").await;
-    CliWorld::run("tests/features/cli.feature").await;
+    tokio::join!(
+        CommentWorld::run("tests/features/comment_request.feature"),
+        CliWorld::run("tests/features/cli.feature")
+    );
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,8 +1,9 @@
 mod steps;
 use cucumber::World as _;
-use steps::CommentWorld;
+use steps::{CliWorld, CommentWorld};
 
 #[tokio::main]
 async fn main() {
-    CommentWorld::run("tests/features").await;
+    CommentWorld::run("tests/features/comment_request.feature").await;
+    CliWorld::run("tests/features/cli.feature").await;
 }

--- a/tests/features/cli.feature
+++ b/tests/features/cli.feature
@@ -4,6 +4,19 @@ Feature: CLI argument parsing
     Given valid CLI arguments
     When they are parsed
     Then parsing succeeds
+    And the socket path is "/run/comenq/socket"
+
+  Scenario: overriding the socket path
+    Given valid CLI arguments
+    And socket path "/tmp/test.sock"
+    When they are parsed
+    Then parsing succeeds
+    And the socket path is "/tmp/test.sock"
+
+  Scenario: missing required arguments
+    Given no CLI arguments
+    When they are parsed
+    Then an error is returned
 
   Scenario Outline: invalid repository slug
     Given CLI arguments with repo slug "<slug>"

--- a/tests/features/cli.feature
+++ b/tests/features/cli.feature
@@ -1,0 +1,18 @@
+Feature: CLI argument parsing
+
+  Scenario: parsing valid arguments
+    Given valid CLI arguments
+    When they are parsed
+    Then parsing succeeds
+
+  Scenario Outline: invalid repository slug
+    Given CLI arguments with repo slug "<slug>"
+    When they are parsed
+    Then an error is returned
+
+    Examples:
+      | slug              |
+      | octocat           |
+      | /repo             |
+      | owner/            |
+      | owner/repo/extra  |

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::expect_used, reason = "simplify test failure output")]
+//! Behavioural test steps for the CLI argument parser.
+//!
+//! These steps drive the Cucumber scenarios that verify valid and
+//! invalid command line inputs, including the optional `--socket`
+//! flag. They ensure the parser surface behaves as documented.
+#![expect(clippy::expect_used, reason = "simplify test failure output")]
 
 use clap::Parser;
 use cucumber::{World, given, then, when};
@@ -49,9 +54,11 @@ fn socket_path(world: &mut CliWorld, path: String) {
 
 #[when("they are parsed")]
 fn they_are_parsed(world: &mut CliWorld) {
-    if let Some(args) = world.args.clone() {
-        world.result = Some(Args::try_parse_from(args));
-    }
+    let args = world
+        .args
+        .clone()
+        .expect("world.args should be set by a given step");
+    world.result = Some(Args::try_parse_from(args));
 }
 
 #[then("parsing succeeds")]

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -1,0 +1,56 @@
+#![allow(clippy::expect_used, reason = "simplify test failure output")]
+
+use clap::Parser;
+use cucumber::{World, given, then, when};
+use std::ffi::OsString;
+
+use comenq::Args;
+
+#[derive(Debug, Default, World)]
+pub struct CliWorld {
+    args: Option<Vec<OsString>>,
+    result: Option<Result<Args, clap::Error>>,
+}
+
+#[given("valid CLI arguments")]
+fn valid_cli_arguments(world: &mut CliWorld) {
+    world.args = Some(vec![
+        OsString::from("comenq"),
+        OsString::from("octocat/hello-world"),
+        OsString::from("1"),
+        OsString::from("Hi"),
+    ]);
+}
+
+#[given(regex = r#"^CLI arguments with repo slug \"(.+)\"$"#)]
+fn cli_args_with_repo_slug(world: &mut CliWorld, slug: String) {
+    world.args = Some(vec![
+        OsString::from("comenq"),
+        OsString::from(slug),
+        OsString::from("1"),
+        OsString::from("Hi"),
+    ]);
+}
+
+#[when("they are parsed")]
+fn they_are_parsed(world: &mut CliWorld) {
+    if let Some(args) = world.args.clone() {
+        world.result = Some(Args::try_parse_from(args));
+    }
+}
+
+#[then("parsing succeeds")]
+fn parsing_succeeds(world: &mut CliWorld) {
+    match world.result.take() {
+        Some(Ok(_)) => {}
+        other => panic!("expected success, got {other:?}"),
+    }
+}
+
+#[then("an error is returned")]
+fn an_error_is_returned(world: &mut CliWorld) {
+    match world.result.take() {
+        Some(Err(_)) => {}
+        other => panic!("expected error, got {other:?}"),
+    }
+}

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -1,2 +1,4 @@
 pub mod comment_steps;
 pub use comment_steps::CommentWorld;
+pub mod cli_steps;
+pub use cli_steps::CliWorld;


### PR DESCRIPTION
## Summary
- implement `Args` struct for the `comenq` client
- validate the `owner/repo` slug using a custom value parser
- expose the CLI utilities as a library for testing
- document the parser decision in the design doc and update the roadmap
- add cucumber scenarios for CLI argument parsing

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6883aca1d15083228f3cbc5ce4442848

## Summary by Sourcery

Implement CLI argument parsing for the comenq client using clap derive, including custom validation for the owner/repo slug, expose parsing logic as a library, update main to use Args::parse, and add comprehensive tests and documentation updates.

New Features:
- Define Args struct with clap derive macro for parsing repo_slug, pr_number, comment_body, and socket
- Integrate custom value parser to validate owner/repo slug format within clap
- Expose CLI parsing utilities in a library (src/lib.rs) to facilitate testing
- Invoke Args::parse in main to wire up CLI argument handling

Enhancements:
- Update design doc with rationale for custom value parser
- Mark CLI parsing and slug validation tasks as complete in the roadmap

Build:
- Add library target in crates/comenq Cargo.toml and update root dev-dependencies for clap and comenq

Documentation:
- Document parser decision in design documentation
- Update roadmap to reflect implemented CLI parsing and validation

Tests:
- Add unit tests for valid and invalid repository slug parsing in Args
- Add cucumber scenarios and step definitions for CLI argument parsing