### PR TITLE
Implement daemon UDS listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "yaque",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ comenq = { path = "crates/comenq" }
 comenqd = { path = "crates/comenqd" }
 ortho_config = { git = "https://github.com/leynos/ortho-config.git", tag = "v0.4.0" }
 tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
+yaque = { workspace = true }
 
 [[test]]
 name = "cucumber"

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use tokio::fs;
 use tokio::io::AsyncReadExt;
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{mpsc, watch};
 use yaque::{Receiver, Sender, channel};
 
 fn build_octocrab(token: &str) -> Result<Octocrab> {
@@ -37,16 +38,30 @@ async fn ensure_queue_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+pub async fn queue_writer(
+    mut sender: Sender,
+    mut rx: mpsc::UnboundedReceiver<Vec<u8>>,
+) -> Result<()> {
+    while let Some(bytes) = rx.recv().await {
+        if let Err(e) = sender.send(bytes).await {
+            tracing::error!(error = %e, "Queue enqueue failed");
+        }
+    }
+    Ok(())
+}
+
 /// Start the daemon with the provided configuration.
 pub async fn run(config: Config) -> Result<()> {
     ensure_queue_dir(&config.queue_path).await?;
     tracing::info!(queue = %config.queue_path.display(), "Queue directory prepared");
     let octocrab = Arc::new(build_octocrab(&config.github_token)?);
-    let (tx, rx) = channel(&config.queue_path)?;
+    let (queue_tx, rx) = channel(&config.queue_path)?;
+    let (client_tx, client_rx) = mpsc::unbounded_channel();
     let cfg = Arc::new(config);
-    let sender = Arc::new(tokio::sync::Mutex::new(tx));
+    let (shutdown_tx, shutdown_rx) = watch::channel(());
 
-    let listener = tokio::spawn(run_listener(cfg.clone(), sender));
+    let writer = tokio::spawn(queue_writer(queue_tx, client_rx));
+    let listener = tokio::spawn(run_listener(cfg.clone(), client_tx, shutdown_rx));
     let worker = tokio::spawn(run_worker(cfg.clone(), rx, octocrab));
 
     tokio::select! {
@@ -60,35 +75,50 @@ pub async fn run(config: Config) -> Result<()> {
         },
     }
 
+    let _ = shutdown_tx.send(());
+    writer.await??;
+
     Ok(())
 }
 
-pub async fn run_listener(config: Arc<Config>, tx: Arc<tokio::sync::Mutex<Sender>>) -> Result<()> {
+pub async fn run_listener(
+    config: Arc<Config>,
+    tx: mpsc::UnboundedSender<Vec<u8>>,
+    mut shutdown: watch::Receiver<()>,
+) -> Result<()> {
     let listener = prepare_listener(&config.socket_path)?;
 
     loop {
-        match listener.accept().await {
-            Ok((stream, _)) => {
-                let tx_clone = Arc::clone(&tx);
-                tokio::spawn(async move {
-                    if let Err(e) = handle_client(stream, tx_clone).await {
-                        tracing::warn!(error = %e, "Client handling failed");
-                    }
-                });
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to accept client connection");
+        tokio::select! {
+            res = listener.accept() => match res {
+                Ok((stream, _)) => {
+                    let tx_clone = tx.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_client(stream, tx_clone).await {
+                            tracing::warn!(error = %e, "Client handling failed");
+                        }
+                    });
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to accept client connection");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            },
+            _ = shutdown.changed() => {
+                break;
             }
         }
     }
+    Ok(())
 }
 
-async fn handle_client(mut stream: UnixStream, tx: Arc<tokio::sync::Mutex<Sender>>) -> Result<()> {
+async fn handle_client(mut stream: UnixStream, tx: mpsc::UnboundedSender<Vec<u8>>) -> Result<()> {
     let mut buffer = Vec::new();
     stream.read_to_end(&mut buffer).await?;
     let request: CommentRequest = serde_json::from_slice(&buffer)?;
     let bytes = serde_json::to_vec(&request)?;
-    tx.lock().await.send(bytes).await?;
+    tx.send(bytes)
+        .map_err(|_| anyhow::anyhow!("queue writer dropped"))?;
     Ok(())
 }
 
@@ -117,11 +147,12 @@ async fn run_worker(config: Arc<Config>, mut rx: Receiver, octocrab: Arc<Octocra
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the daemon tasks.
     use super::*;
     use tempfile::tempdir;
     use tokio::io::AsyncWriteExt;
     use tokio::net::{UnixListener, UnixStream};
-    use tokio::sync::Mutex;
+    use tokio::sync::{mpsc, watch};
     use tokio::time::{Duration, Instant, sleep};
 
     #[tokio::test]
@@ -179,10 +210,11 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let queue_path = dir.path().join("q");
         let (sender, mut receiver) = channel(&queue_path).expect("channel");
-        let tx = Arc::new(Mutex::new(sender));
+        let (client_tx, mut writer_rx) = mpsc::unbounded_channel();
+        let writer = tokio::spawn(queue_writer(sender, writer_rx));
 
         let (mut client, server) = UnixStream::pair().expect("pair");
-        let handle = tokio::spawn(handle_client(server, Arc::clone(&tx)));
+        let handle = tokio::spawn(handle_client(server, client_tx));
 
         let req = CommentRequest {
             owner: "o".into(),
@@ -194,6 +226,7 @@ mod tests {
         client.write_all(&payload).await.expect("write");
         client.shutdown().await.expect("shutdown");
         handle.await.expect("join").expect("client");
+        drop(writer); // stop queue writer
 
         let guard = receiver.recv().await.expect("recv");
         let stored: CommentRequest = serde_json::from_slice(&guard).expect("parse");
@@ -211,9 +244,11 @@ mod tests {
         });
 
         let (sender, mut receiver) = channel(&cfg.queue_path).expect("channel");
-        let tx = Arc::new(Mutex::new(sender));
+        let (client_tx, writer_rx) = mpsc::unbounded_channel();
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let writer = tokio::spawn(queue_writer(sender, writer_rx));
 
-        let listener_task = tokio::spawn(run_listener(cfg.clone(), tx.clone()));
+        let listener_task = tokio::spawn(run_listener(cfg.clone(), client_tx, shutdown_rx));
 
         // Wait for socket to exist
         for _ in 0..10 {
@@ -241,5 +276,7 @@ mod tests {
         assert_eq!(stored, req);
 
         listener_task.abort();
+        let _ = shutdown_tx.send(());
+        drop(writer);
     }
 }

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -1016,10 +1016,10 @@ derives both `Serialize` and `Deserialize`. The daemon now spawns a Unix
 listener and queue worker as described above. Structured logging is initialised
 using `tracing_subscriber` with JSON output controlled by the `RUST_LOG`
 environment variable. The queue directory is created asynchronously on start if
-it does not already exist before `yaque` opens it. The listener wraps the
-`yaque::Sender` in a `tokio::sync::Mutex` so each connection handler can
-enqueue requests concurrently while maintaining the queue's single-writer
-guarantee.
+it does not already exist before `yaque` opens it. Incoming requests are
+forwarded from the listener to a dedicated queue writer task over a Tokio
+`mpsc` channel. This task serializes writes to the `yaque::Sender`, preserving
+single-writer semantics without per-connection locking.
 
 ## Works cited
 

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -1016,7 +1016,10 @@ derives both `Serialize` and `Deserialize`. The daemon now spawns a Unix
 listener and queue worker as described above. Structured logging is initialised
 using `tracing_subscriber` with JSON output controlled by the `RUST_LOG`
 environment variable. The queue directory is created asynchronously on start if
-it does not already exist before `yaque` opens it.
+it does not already exist before `yaque` opens it. The listener wraps the
+`yaque::Sender` in a `tokio::sync::Mutex` so each connection handler can
+enqueue requests concurrently while maintaining the queue's single-writer
+guarantee.
 
 ## Works cited
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,17 +45,17 @@
 
 ## Milestone 4: `comenqd` Daemon — UDS Listener Task
 
-- [ ] Implement the `run_listener` async task.
+- [x] Implement the `run_listener` async task.
 
-- [ ] Bind a `tokio::net::UnixListener` to the configured socket path, ensuring
+- [x] Bind a `tokio::net::UnixListener` to the configured socket path, ensuring
   any stale socket file is removed first.
 
-- [ ] Set the socket file permissions to `0o660` to enforce the security model.
+- [x] Set the socket file permissions to `0o660` to enforce the security model.
 
-- [ ] Create an acceptance loop (`listener.accept().await`) that spawns a new
+- [x] Create an acceptance loop (`listener.accept().await`) that spawns a new
   task for each incoming client connection.
 
-- [ ] Implement the `handle_client` task to read the JSON payload, deserialize
+- [x] Implement the `handle_client` task to read the JSON payload, deserialize
   it into a `CommentRequest`, and enqueue it using the `yaque` sender.
 
 ## Milestone 5: `comenqd` Daemon — Queue Worker Task

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,6 +1,6 @@
 mod steps;
 use cucumber::World as _;
-use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld};
+use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld};
 
 #[tokio::main]
 async fn main() {
@@ -9,5 +9,6 @@ async fn main() {
         ClientWorld::run("tests/features/client_main.feature"),
         CommentWorld::run("tests/features/comment_request.feature"),
         ConfigWorld::run("tests/features/config.feature"),
+        ListenerWorld::run("tests/features/listener.feature"),
     );
 }

--- a/tests/features/listener.feature
+++ b/tests/features/listener.feature
@@ -1,0 +1,11 @@
+Feature: Daemon listener
+
+  Scenario: handling a valid request
+    Given a running listener task
+    When a client sends a valid request
+    Then the request is enqueued
+
+  Scenario: handling invalid JSON
+    Given a running listener task
+    When a client sends invalid JSON
+    Then the request is rejected

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -1,8 +1,6 @@
-#![allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "simplify test failure output"
-)]
+//! Behavioural test steps for the listener task.
+#![expect(clippy::expect_used, reason = "simplify test failure output")]
+#![expect(clippy::unwrap_used, reason = "simplify test failure output")]
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -27,7 +25,6 @@ pub struct ListenerWorld {
     shutdown: Option<watch::Sender<()>>,
     writer: Option<tokio::task::JoinHandle<()>>,
     handle: Option<tokio::task::JoinHandle<()>>,
-    client_result: Option<Result<(), std::io::Error>>, // not used but for uniform
 }
 
 impl std::fmt::Debug for ListenerWorld {
@@ -85,7 +82,7 @@ async fn client_sends_valid(world: &mut ListenerWorld) {
         body: "b".into(),
     };
     let data = serde_json::to_vec(&req).unwrap();
-    world.client_result = Some(stream.write_all(&data).await);
+    stream.write_all(&data).await.unwrap();
     stream.shutdown().await.expect("shutdown");
 }
 
@@ -95,7 +92,7 @@ async fn client_sends_invalid(world: &mut ListenerWorld) {
     let mut stream = UnixStream::connect(&cfg.socket_path)
         .await
         .expect("connect");
-    world.client_result = Some(stream.write_all(b"not json").await);
+    stream.write_all(b"not json").await.unwrap();
     stream.shutdown().await.expect("shutdown");
 }
 

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -1,0 +1,116 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "simplify test failure output"
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cucumber::{World, given, then, when};
+use tempfile::TempDir;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+use comenq_lib::CommentRequest;
+use comenqd::config::Config;
+use comenqd::daemon::run_listener;
+use yaque::channel;
+
+#[derive(Default, World)]
+pub struct ListenerWorld {
+    dir: Option<TempDir>,
+    cfg: Option<Arc<Config>>,
+    sender: Option<Arc<Mutex<yaque::Sender>>>,
+    receiver: Option<yaque::Receiver>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+    client_result: Option<Result<(), std::io::Error>>, // not used but for uniform
+}
+
+impl std::fmt::Debug for ListenerWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListenerWorld").finish()
+    }
+}
+
+#[given("a running listener task")]
+async fn running_listener(world: &mut ListenerWorld) {
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = Arc::new(Config {
+        github_token: String::from("t"),
+        socket_path: dir.path().join("sock"),
+        queue_path: dir.path().join("q"),
+        cooldown_period_seconds: 1,
+    });
+    let (sender, receiver) = channel(&cfg.queue_path).expect("channel");
+    let sender_arc = Arc::new(Mutex::new(sender));
+    let cfg_clone = cfg.clone();
+    let sender_clone = sender_arc.clone();
+    let handle = tokio::spawn(async move {
+        run_listener(cfg_clone, sender_clone).await.unwrap();
+    });
+    world.dir = Some(dir);
+    world.cfg = Some(cfg);
+    world.sender = Some(sender_arc);
+    world.receiver = Some(receiver);
+    world.handle = Some(handle);
+    // wait for socket create
+    for _ in 0..10 {
+        if world.cfg.as_ref().unwrap().socket_path.exists() {
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[when("a client sends a valid request")]
+async fn client_sends_valid(world: &mut ListenerWorld) {
+    let cfg = world.cfg.as_ref().unwrap();
+    let mut stream = UnixStream::connect(&cfg.socket_path)
+        .await
+        .expect("connect");
+    let req = CommentRequest {
+        owner: "o".into(),
+        repo: "r".into(),
+        pr_number: 1,
+        body: "b".into(),
+    };
+    let data = serde_json::to_vec(&req).unwrap();
+    world.client_result = Some(stream.write_all(&data).await);
+    stream.shutdown().await.expect("shutdown");
+}
+
+#[when("a client sends invalid JSON")]
+async fn client_sends_invalid(world: &mut ListenerWorld) {
+    let cfg = world.cfg.as_ref().unwrap();
+    let mut stream = UnixStream::connect(&cfg.socket_path)
+        .await
+        .expect("connect");
+    world.client_result = Some(stream.write_all(b"not json").await);
+    stream.shutdown().await.expect("shutdown");
+}
+
+#[then("the request is enqueued")]
+async fn request_enqueued(world: &mut ListenerWorld) {
+    let receiver = world.receiver.as_mut().unwrap();
+    let guard = receiver.recv().await.expect("recv");
+    let req: CommentRequest = serde_json::from_slice(&guard).unwrap();
+    assert_eq!(req.owner, "o");
+}
+
+#[then("the request is rejected")]
+async fn request_rejected(world: &mut ListenerWorld) {
+    let receiver = world.receiver.as_mut().unwrap();
+    let res = tokio::time::timeout(Duration::from_millis(100), receiver.recv()).await;
+    assert!(res.is_err());
+}
+
+impl Drop for ListenerWorld {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -6,3 +6,5 @@ pub mod comment_steps;
 pub use comment_steps::CommentWorld;
 pub mod config_steps;
 pub use config_steps::ConfigWorld;
+pub mod listener_steps;
+pub use listener_steps::ListenerWorld;


### PR DESCRIPTION
## Summary
- implement `run_listener` with per-client tasks and queue enqueue
- guard sender with `tokio::sync::Mutex`
- add unit tests for listener and client handling
- provide behavioural tests for daemon listener
- document the design decision for shared mutex
- mark Milestone 4 tasks as done

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688621ceff28832290bbe00dcf3de623

## Summary by Sourcery

Implement a Unix domain socket listener for the daemon that spawns concurrent handlers to enqueue JSON requests into the queue, add necessary synchronization, and cover the new functionality with unit and behavioural tests while updating documentation and dependencies.

New Features:
- Add a Unix domain socket listener task that accepts connections and spawns per-client handlers
- Enable clients to send JSON-encoded CommentRequest messages which are enqueued into the yaque queue

Enhancements:
- Wrap the yaque::Sender in a tokio::sync::Mutex to allow concurrent enqueues while preserving single-writer safety
- Log listener accept and client handling errors using structured tracing

Build:
- Add yaque as a dependency in Cargo.toml

Documentation:
- Document the shared mutex design decision in the architecture doc
- Mark Milestone 4 tasks as completed in the roadmap

Tests:
- Add unit tests for listener setup, socket permissions, and handle_client enqueuing
- Add Cucumber feature and step definitions for listener behaviour under valid and invalid requests