### PR TITLE
Add timeout check in listener test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
-  logic. Prefer generators, comprehensions, and declarative code to
-  imperative repetition when readable.
+  logic. Prefer generators, comprehensions, and declarative code to imperative
+  repetition when readable.
 - **Small, meaningful functions.** Functions must be small, clear in purpose,
   single responsibility, and obey command/query segregation.
 - **Clear commit messages.** Commit messages should be descriptive, explaining

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -60,13 +60,20 @@ async fn running_listener(world: &mut ListenerWorld) {
     world.writer = Some(writer);
     world.receiver = Some(receiver);
     world.handle = Some(handle);
-    // wait for socket create
+
+    // wait up to 100 ms for the socket file to appear
+    let socket_path = &world.cfg.as_ref().unwrap().socket_path;
     for _ in 0..10 {
-        if world.cfg.as_ref().unwrap().socket_path.exists() {
+        if socket_path.exists() {
             break;
         }
         sleep(Duration::from_millis(10)).await;
     }
+    assert!(
+        socket_path.exists(),
+        "socket file {} not created within timeout",
+        socket_path.display()
+    );
 }
 
 #[when("a client sends a valid request")]

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -62,7 +62,11 @@ async fn running_listener(world: &mut ListenerWorld) {
     world.handle = Some(handle);
 
     // wait up to 100 ms for the socket file to appear
-    let socket_path = &world.cfg.as_ref().unwrap().socket_path;
+    let socket_path = &world
+        .cfg
+        .as_ref()
+        .expect("config not initialised in ListenerWorld")
+        .socket_path;
     for _ in 0..10 {
         if socket_path.exists() {
             break;


### PR DESCRIPTION
## Summary
- assert the Unix socket appears within 100ms in listener steps
- keep documentation formatting up to date

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6886b7488dd48322a83ae2c33ae5596b

## Summary by Sourcery

Add timeout-based check in listener test to assert socket creation within 100ms and update line wrapping in AGENTS.md

Documentation:
- Update AGENTS.md line wrapping for consistent formatting

Tests:
- Add timeout loop and assertion in listener test to ensure socket file appears within 100ms