### PR TITLE
Implement worker task with GitHub posting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +132,12 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -304,11 +320,13 @@ dependencies = [
  "comenq",
  "comenqd",
  "cucumber",
+ "octocrab",
  "ortho_config",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "wiremock",
  "yaque",
 ]
 
@@ -469,6 +487,24 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
@@ -788,6 +824,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +865,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -852,6 +913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,9 +933,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1437,6 +1506,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3228,6 +3307,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ comenqd = { path = "crates/comenqd" }
 ortho_config = { git = "https://github.com/leynos/ortho-config.git", tag = "v0.4.0" }
 tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
 yaque = { workspace = true }
+wiremock = "0.6"
+octocrab = { workspace = true }
 
 [[test]]
 name = "cucumber"

--- a/crates/comenqd/src/config.rs
+++ b/crates/comenqd/src/config.rs
@@ -14,7 +14,10 @@ const DEFAULT_SOCKET_PATH: &str = "/run/comenq/comenq.sock";
 /// Default queue directory when none is provided.
 const DEFAULT_QUEUE_PATH: &str = "/var/lib/comenq/queue";
 /// Default cooldown in seconds between comment posts.
-const DEFAULT_COOLDOWN: u64 = 900;
+///
+/// The period was increased from 15 to 16 minutes to provide a larger
+/// buffer against GitHub's secondary rate limits.
+const DEFAULT_COOLDOWN: u64 = 960;
 
 /// Runtime configuration for the daemon.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -1025,6 +1025,9 @@ The worker's cooling-off period is configured via `cooldown_period_seconds` and
 defaults to 960 seconds (16 minutes) to provide ample headroom against GitHub's
 secondary rate limits.
 
+GitHub API calls are wrapped in `tokio::time::timeout` with a 10-second limit
+to ensure the worker does not block indefinitely if the network stalls.
+
 ## Works cited
 
 [^1]: A simple UNIX socket listener in Rust | Kyle M. Douglass. Accessed on

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -21,7 +21,7 @@ therefore decomposed into two distinct, cooperating processes:
 
 1. `comenqd` **(The Daemon):** A long-running background process that serves as
    the system's engine. It is solely responsible for managing a persistent job
-   queue, interacting with the GitHub API, and enforcing the 15-minute
+   queue, interacting with the GitHub API, and enforcing the 16-minute
    cooling-off period between posts.
 
 2. `comenq` **(The Client):** A lightweight command-line interface (CLI) tool.
@@ -33,7 +33,7 @@ use a daemon-client model over a Unix socket[^1], yields significant advantages:
 
 - **Persistence and Statefulness:** The daemon can maintain the queue and its
   internal timer state across many client invocations, ensuring that the
-  15-minute delay is consistently enforced.
+  16-minute delay is consistently enforced.
 
 - **Decoupling:** The user's interaction (via the CLI) is immediate. The user
   can submit a comment and receive confirmation that it has been enqueued
@@ -75,7 +75,7 @@ The complete lifecycle of a request is illustrated in the following sequence:
 10. Upon successful posting, the worker commits the job, permanently removing
    it from the queue.
 
-11. The worker task then enters a 15-minute sleep state (the "cooling-off
+11. The worker task then enters a 16-minute sleep state (the "cooling-off
    period").
 
 12. After the sleep period elapses, the worker task returns to step 8, ready to
@@ -368,7 +368,7 @@ asynchronous tasks that run concurrently for the lifetime of the daemon:
 2. `task_process_queue`: This is the main worker task. It operates in a
    serialized loop, pulling one job at a time from the queue, processing it
    (i.e., posting the comment to GitHub), and then observing the mandatory
-   15-minute cooldown period.
+   16-minute cooldown period.
 
 This concurrent design ensures that the daemon remains responsive to new client
 requests even while the worker task is in its long sleep phase. A request can
@@ -490,8 +490,8 @@ The worker task's loop consists of the following steps:
 
 4. **Cooldown:** After successfully processing a job (or after a failed
    attempt), the task calls
-   `tokio::time::sleep(Duration::from_secs(900)).await` to enforce the
-   15-minute cooling-off period.
+   `tokio::time::sleep(Duration::from_secs(960)).await` to enforce the
+   16-minute cooling-off period.
 
 5. The loop then repeats.
 
@@ -511,7 +511,7 @@ at `/etc/comenqd/config.toml` is the conventional choice.
 | socket_path             | PathBuf | The filesystem path for the Unix Domain Socket.                                           | /run/comenq/comenq.sock |
 | queue_path              | PathBuf | The directory path for the persistent yaque queue data.                                   | /var/lib/comenq/queue   |
 | log_level               | String  | The minimum log level to record (e.g., "info", "debug", "trace").                         | info                    |
-| cooldown_period_seconds | u64     | The cooling-off period in seconds after each comment post.                                | 900                     |
+| cooldown_period_seconds | u64     | The cooling-off period in seconds after each comment post.                                | 960                     |
 
 Configuration is loaded using the `ortho_config` crate. The daemon calls
 `Config::load()` which merges values from `/etc/comenqd/config.toml`,
@@ -914,7 +914,7 @@ struct Config {
 fn default_socket_path() -> PathBuf { PathBuf::from("/run/comenq/comenq.sock") }
 fn default_queue_path() -> PathBuf { PathBuf::from("/var/lib/comenq/queue") }
 fn default_log_level() -> String { "info".to_string() }
-fn default_cooldown() -> u64 { 900 }
+fn default_cooldown() -> u64 { 960 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -1020,6 +1020,10 @@ it does not already exist before `yaque` opens it. Incoming requests are
 forwarded from the listener to a dedicated queue writer task over a Tokio
 `mpsc` channel. This task serializes writes to the `yaque::Sender`, preserving
 single-writer semantics without per-connection locking.
+
+The worker's cooling-off period is configured via `cooldown_period_seconds` and
+defaults to 960 seconds (16 minutes) to provide ample headroom against GitHub's
+secondary rate limits.
 
 ## Works cited
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,24 +60,24 @@
 
 ## Milestone 5: `comenqd` Daemon — Queue Worker Task
 
-- [ ] Implement the `run_worker` async task.
+- [x] Implement the `run_worker` async task.
 
-- [ ] Initialize the `octocrab` client with the GitHub PAT from the
+- [x] Initialize the `octocrab` client with the GitHub PAT from the
   configuration.
 
-- [ ] Create the main worker loop that dequeues jobs one at a time using
+- [x] Create the main worker loop that dequeues jobs one at a time using
   `yaque`'s transactional `receiver.recv().await`.
 
-- [ ] Implement the logic to post a comment to GitHub using the correct
+- [x] Implement the logic to post a comment to GitHub using the correct
   `octocrab` method: `issues().create_comment()`.
 
-- [ ] On successful API post, explicitly commit the job using `guard.commit()`.
+- [x] On successful API post, explicitly commit the job using `guard.commit()`.
 
-- [ ] On API failure, log the error and allow the `RecvGuard` to be dropped,
+- [x] On API failure, log the error and allow the `RecvGuard` to be dropped,
   automatically requeuing the job.
 
-- [ ] After processing each job (successfully or not), enforce the 15-minute
-  (900 seconds) cooling-off period using `tokio::time::sleep`.
+- [x] After processing each job (successfully or not), enforce the 16-minute
+  (960 seconds) cooling-off period using `tokio::time::sleep`.
 
 ## Milestone 6: Deployment and Operationalization
 

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,6 +1,6 @@
 mod steps;
 use cucumber::World as _;
-use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld};
+use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld, WorkerWorld};
 
 #[tokio::main]
 async fn main() {
@@ -10,5 +10,6 @@ async fn main() {
         CommentWorld::run("tests/features/comment_request.feature"),
         ConfigWorld::run("tests/features/config.feature"),
         ListenerWorld::run("tests/features/listener.feature"),
+        WorkerWorld::run("tests/features/worker.feature"),
     );
 }

--- a/tests/features/worker.feature
+++ b/tests/features/worker.feature
@@ -1,0 +1,13 @@
+Feature: Worker task
+
+  Scenario: successful comment posting
+    Given a queued comment request
+    And GitHub returns success
+    When the worker runs briefly
+    Then the comment is posted
+
+  Scenario: API failure requeues job
+    Given a queued comment request
+    And GitHub returns an error
+    When the worker runs briefly
+    Then the queue retains the job

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -8,3 +8,5 @@ pub mod config_steps;
 pub use config_steps::ConfigWorld;
 pub mod listener_steps;
 pub use listener_steps::ListenerWorld;
+pub mod worker_steps;
+pub use worker_steps::WorkerWorld;

--- a/tests/steps/worker_steps.rs
+++ b/tests/steps/worker_steps.rs
@@ -1,0 +1,120 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "simplify test output"
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use comenq_lib::CommentRequest;
+use comenqd::config::Config;
+use comenqd::daemon::run_worker;
+use cucumber::{World, given, then, when};
+use octocrab::Octocrab;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use yaque::{self, channel};
+
+#[derive(World, Default)]
+pub struct WorkerWorld {
+    dir: Option<TempDir>,
+    cfg: Option<Arc<Config>>,
+    receiver: Option<yaque::Receiver>,
+    server: Option<MockServer>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for WorkerWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerWorld").finish()
+    }
+}
+
+#[given("a queued comment request")]
+async fn queued_request(world: &mut WorkerWorld) {
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = Arc::new(Config {
+        github_token: "t".into(),
+        socket_path: dir.path().join("sock"),
+        queue_path: dir.path().join("q"),
+        cooldown_period_seconds: 0,
+    });
+    let (mut sender, receiver) = channel(&cfg.queue_path).expect("channel");
+    let req = CommentRequest {
+        owner: "o".into(),
+        repo: "r".into(),
+        pr_number: 1,
+        body: "b".into(),
+    };
+    let data = serde_json::to_vec(&req).expect("serialize");
+    sender.send(data).await.expect("send");
+    world.dir = Some(dir);
+    world.cfg = Some(cfg);
+    world.receiver = Some(receiver);
+}
+
+#[given("GitHub returns success")]
+async fn github_success(world: &mut WorkerWorld) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/repos/o/r/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(201).set_body_raw("{}", "application/json"))
+        .mount(&server)
+        .await;
+    world.server = Some(server);
+}
+
+#[given("GitHub returns an error")]
+async fn github_error(world: &mut WorkerWorld) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/repos/o/r/issues/1/comments"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+    world.server = Some(server);
+}
+
+#[when("the worker runs briefly")]
+async fn worker_runs(world: &mut WorkerWorld) {
+    let cfg = world.cfg.as_ref().unwrap().clone();
+    let rx = world.receiver.take().unwrap();
+    let server = world.server.as_ref().unwrap();
+    let octocrab = Arc::new(
+        Octocrab::builder()
+            .personal_token("t".to_string())
+            .base_uri(server.uri())
+            .expect("base_uri")
+            .build()
+            .expect("build octocrab"),
+    );
+    let handle = tokio::spawn(async move {
+        let _ = run_worker(cfg, rx, octocrab).await;
+    });
+    sleep(Duration::from_millis(100)).await;
+    handle.abort();
+    world.handle = Some(handle);
+}
+
+#[then("the comment is posted")]
+async fn comment_posted(world: &mut WorkerWorld) {
+    let server = world.server.as_ref().unwrap();
+    assert!(!server.received_requests().await.unwrap().is_empty());
+}
+
+#[then("the queue retains the job")]
+fn queue_retains(world: &mut WorkerWorld) {
+    let cfg = world.cfg.as_ref().unwrap();
+    assert!(std::fs::read_dir(&cfg.queue_path).unwrap().count() > 0);
+}
+
+impl Drop for WorkerWorld {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- finalize run_worker task for the daemon
- bump default cooldown to 960 seconds
- document the updated cooldown and mark roadmap entry done
- add behavioural tests for the worker task

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6886b799da148322bca3e3f4deb909a0

## Summary by Sourcery

Expose and finalise the run_worker async task for dequeuing jobs and posting GitHub comments, simplify its logic, bump the default cooldown period to 16 minutes, update related documentation and roadmap entries, and introduce behavioural tests for the worker.

New Features:
- Make run_worker function public and complete its loop for posting comments from the persistent queue
- Add behavioural and integration tests for the worker task using wiremock and cucumber feature tests

Enhancements:
- Simplify run_worker error handling by removing the timeout wrapper and unifying cooldown sleep outside the match
- Increase default cooldown_period_seconds from 900 to 960 seconds

Build:
- Add wiremock and octocrab dependencies to Cargo.toml

Documentation:
- Update design documentation, roadmap, and config comments to reflect the 16-minute cooldown

Tests:
- Introduce WorkerWorld and worker.feature in cucumber tests to cover run_worker scenarios