### PR TITLE
Refactor env var guard

### DIFF
--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,4 +1,5 @@
 mod steps;
+mod support;
 use cucumber::World as _;
 use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld, WorkerWorld};
 

--- a/tests/support/env_guard.rs
+++ b/tests/support/env_guard.rs
@@ -41,3 +41,63 @@ pub fn remove_env_var(key: &str) {
     // Safety: tests execute serially so no concurrent access occurs.
     unsafe { std::env::remove_var(key) };
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[serial_test::serial]
+    fn set_env_var_sets_variable() {
+        let key = "ENV_GUARD_SET";
+        super::remove_env_var(key);
+        assert!(std::env::var(key).is_err());
+
+        super::set_env_var(key, "value");
+        assert_eq!(std::env::var(key).unwrap(), "value");
+
+        super::remove_env_var(key);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_env_var_removes_variable() {
+        let key = "ENV_GUARD_REMOVE";
+        std::env::set_var(key, "to_remove");
+        assert_eq!(std::env::var(key).unwrap(), "to_remove");
+
+        super::remove_env_var(key);
+        assert!(std::env::var(key).is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_env_var_when_unset_is_noop() {
+        let key = "ENV_GUARD_REMOVE_UNSET";
+        super::remove_env_var(key);
+        assert!(std::env::var(key).is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn nested_env_var_guard_restores_previous_value() {
+        let key = "ENV_GUARD_TEST_NESTED";
+        super::remove_env_var(key);
+
+        std::env::set_var(key, "initial");
+        assert_eq!(std::env::var(key).unwrap(), "initial");
+
+        let guard1 = super::EnvVarGuard::set(key, "first");
+        assert_eq!(std::env::var(key).unwrap(), "first");
+
+        {
+            let _guard2 = super::EnvVarGuard::set(key, "second");
+            assert_eq!(std::env::var(key).unwrap(), "second");
+        }
+
+        assert_eq!(std::env::var(key).unwrap(), "first");
+
+        drop(guard1);
+        assert_eq!(std::env::var(key).unwrap(), "initial");
+
+        super::remove_env_var(key);
+    }
+}

--- a/tests/support/env_guard.rs
+++ b/tests/support/env_guard.rs
@@ -1,0 +1,43 @@
+//! Test helpers for managing environment variables.
+//!
+//! `EnvVarGuard` temporarily sets an environment variable and restores the
+//! previous value on drop.
+
+#[derive(Debug)]
+pub struct EnvVarGuard {
+    key: String,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    /// Set an environment variable for the lifetime of the returned guard.
+    pub fn set(key: &str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        set_env_var(key, value);
+        Self {
+            key: key.to_string(),
+            original,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(v) => set_env_var(&self.key, v),
+            None => remove_env_var(&self.key),
+        }
+    }
+}
+
+/// Safely set an environment variable for tests.
+pub fn set_env_var(key: &str, value: &str) {
+    // Safety: tests execute serially so no concurrent access occurs.
+    unsafe { std::env::set_var(key, value) };
+}
+
+/// Safely remove an environment variable for tests.
+pub fn remove_env_var(key: &str) {
+    // Safety: tests execute serially so no concurrent access occurs.
+    unsafe { std::env::remove_var(key) };
+}

--- a/tests/support/env_guard.rs
+++ b/tests/support/env_guard.rs
@@ -64,7 +64,7 @@ mod tests {
     #[serial_test::serial]
     fn remove_env_var_removes_variable() {
         let key = "ENV_GUARD_REMOVE";
-        std::env::set_var(key, "to_remove");
+        super::set_env_var(key, "to_remove");
         assert_eq!(std::env::var(key).unwrap(), "to_remove");
 
         super::remove_env_var(key);
@@ -85,7 +85,7 @@ mod tests {
         let key = "ENV_GUARD_TEST_NESTED";
         super::remove_env_var(key);
 
-        std::env::set_var(key, "initial");
+        super::set_env_var(key, "initial");
         assert_eq!(std::env::var(key).unwrap(), "initial");
 
         let guard1 = super::EnvVarGuard::set(key, "first");

--- a/tests/support/env_guard.rs
+++ b/tests/support/env_guard.rs
@@ -30,15 +30,18 @@ impl Drop for EnvVarGuard {
     }
 }
 
-/// Safely set an environment variable for tests.
+/// Set an environment variable for tests.
+///
+/// The nightly compiler marks `std::env::set_var` as `unsafe`.
+/// Tests run serially so using it is acceptable here.
 pub fn set_env_var(key: &str, value: &str) {
-    // Safety: tests execute serially so no concurrent access occurs.
     unsafe { std::env::set_var(key, value) };
 }
 
-/// Safely remove an environment variable for tests.
+/// Remove an environment variable for tests.
+///
+/// `std::env::remove_var` is also `unsafe` on nightly.
 pub fn remove_env_var(key: &str) {
-    // Safety: tests execute serially so no concurrent access occurs.
     unsafe { std::env::remove_var(key) };
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,3 @@
+//! Support utilities shared by tests.
+
+pub mod env_guard;


### PR DESCRIPTION
## Summary
- centralize environment variable guard for tests
- use the shared guard in configuration steps and tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6888f7ea4f2083228cdd174537e3132b

## Summary by Sourcery

Centralize environment variable guard logic for tests into a shared support module and update existing tests to use the common implementation

Enhancements:
- Extract EnvVarGuard and its helper functions into tests/support/env_guard.rs
- Re-export shared guard utilities through support modules in config and test directories
- Update config and step tests to import and use the centralized EnvVarGuard and remove_env_var