### PR TITLE
Add wait_for_file util for tests

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -168,9 +168,12 @@ mod tests {
     use tokio::io::AsyncWriteExt;
     use tokio::net::{UnixListener, UnixStream};
     use tokio::sync::{mpsc, watch};
-    use tokio::time::{Duration, Instant, sleep};
+    use tokio::time::{Duration, sleep};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+    #[path = "../../../../../tests/support/util.rs"]
+    mod util;
+    use util::wait_for_file;
 
     async fn setup_run_worker(status: u16) -> (MockServer, Arc<Config>, Receiver, Arc<Octocrab>) {
         let dir = tempdir().expect("tempdir");
@@ -235,14 +238,7 @@ mod tests {
 
         let handle = tokio::spawn(run(cfg.clone()));
 
-        let start = Instant::now();
-        let timeout = Duration::from_secs(2);
-        loop {
-            if cfg.queue_path.is_dir() || start.elapsed() > timeout {
-                break;
-            }
-            sleep(Duration::from_millis(10)).await;
-        }
+        wait_for_file(&cfg.queue_path, 200, Duration::from_millis(10)).await;
 
         handle.abort();
         assert!(cfg.queue_path.is_dir(), "queue directory not created");
@@ -306,13 +302,7 @@ mod tests {
 
         let listener_task = tokio::spawn(run_listener(cfg.clone(), client_tx, shutdown_rx));
 
-        // Wait for socket to exist
-        for _ in 0..10 {
-            if cfg.socket_path.exists() {
-                break;
-            }
-            sleep(Duration::from_millis(10)).await;
-        }
+        wait_for_file(&cfg.socket_path, 10, Duration::from_millis(10)).await;
 
         let mut stream = UnixStream::connect(&cfg.socket_path)
             .await

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,4 +1,5 @@
 mod steps;
+mod support;
 use cucumber::World as _;
 use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld, WorkerWorld};
 

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -5,12 +5,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::support::util::wait_for_file;
 use cucumber::{World, given, then, when};
 use tempfile::TempDir;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::sync::{mpsc, watch};
-use tokio::time::sleep;
 
 use comenq_lib::CommentRequest;
 use comenqd::config::Config;
@@ -61,20 +61,13 @@ async fn running_listener(world: &mut ListenerWorld) {
     world.receiver = Some(receiver);
     world.handle = Some(handle);
 
-    // wait up to 100 ms for the socket file to appear
     let socket_path = &world
         .cfg
         .as_ref()
         .expect("config not initialised in ListenerWorld")
         .socket_path;
-    for _ in 0..10 {
-        if socket_path.exists() {
-            break;
-        }
-        sleep(Duration::from_millis(10)).await;
-    }
     assert!(
-        socket_path.exists(),
+        wait_for_file(socket_path, 10, Duration::from_millis(10)).await,
         "socket file {} not created within timeout",
         socket_path.display()
     );

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,3 @@
+//! Test support utilities.
+
+pub mod util;

--- a/tests/support/util.rs
+++ b/tests/support/util.rs
@@ -1,0 +1,30 @@
+//! Utility helpers for asynchronous tests.
+//!
+//! Provides functions to synchronize with background tasks in tests.
+
+use std::path::Path;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Wait for a file to appear within the given number of tries.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use std::path::Path;
+/// use std::time::Duration;
+/// use tests::support::util::wait_for_file;
+///
+/// let path = Path::new("/tmp/example.sock");
+/// let found = wait_for_file(path, 5, Duration::from_millis(10)).await;
+/// assert!(found);
+/// ```
+pub async fn wait_for_file(path: &Path, tries: u32, delay: Duration) -> bool {
+    for _ in 0..tries {
+        if path.exists() {
+            return true;
+        }
+        sleep(delay).await;
+    }
+    path.exists()
+}


### PR DESCRIPTION
## Summary
- add `wait_for_file` async helper
- use `wait_for_file` in listener steps and daemon tests
- expose support module to cucumber tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6888f7f383e08322ad8cf2ffd76d7a4a