### PR TITLE
Add reusable test helpers

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -164,8 +164,12 @@ pub async fn run_worker(
 mod tests {
     //! Tests for the daemon tasks.
     use super::*;
-    #[path = "../../../../../tests/util/test_helpers.rs"]
-    mod test_helpers;
+    mod test_helpers {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/util/test_helpers.rs"
+        ));
+    }
     use tempfile::tempdir;
     use test_helpers::{octocrab_for, temp_config};
     use tokio::io::AsyncWriteExt;

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -164,9 +164,8 @@ pub async fn run_worker(
 mod tests {
     //! Tests for the daemon tasks.
     use super::*;
-    mod test_helpers {
-        include!("../../../tests/util/test_helpers.rs");
-    }
+    #[path = "../../../../../tests/util/test_helpers.rs"]
+    mod test_helpers;
     use tempfile::tempdir;
     use test_helpers::{octocrab_for, temp_config};
     use tokio::io::AsyncWriteExt;

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,4 +1,5 @@
 mod steps;
+mod util;
 use cucumber::World as _;
 use steps::{CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld, WorkerWorld};
 

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -12,6 +12,7 @@ use tokio::net::UnixStream;
 use tokio::sync::{mpsc, watch};
 use tokio::time::sleep;
 
+use crate::util::test_helpers::temp_config;
 use comenq_lib::CommentRequest;
 use comenqd::config::Config;
 use comenqd::daemon::{queue_writer, run_listener};
@@ -36,12 +37,7 @@ impl std::fmt::Debug for ListenerWorld {
 #[given("a running listener task")]
 async fn running_listener(world: &mut ListenerWorld) {
     let dir = TempDir::new().expect("tempdir");
-    let cfg = Arc::new(Config {
-        github_token: String::from("t"),
-        socket_path: dir.path().join("sock"),
-        queue_path: dir.path().join("q"),
-        cooldown_period_seconds: 1,
-    });
+    let cfg = Arc::new(temp_config(&dir));
     let (sender, receiver) = channel(&cfg.queue_path).expect("channel");
     let (client_tx, writer_rx) = mpsc::unbounded_channel();
     let (shutdown_tx, shutdown_rx) = watch::channel(());

--- a/tests/steps/worker_steps.rs
+++ b/tests/steps/worker_steps.rs
@@ -7,11 +7,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::util::test_helpers::{octocrab_for, temp_config};
 use comenq_lib::CommentRequest;
 use comenqd::config::Config;
 use comenqd::daemon::run_worker;
 use cucumber::{World, given, then, when};
-use octocrab::Octocrab;
 use tempfile::TempDir;
 use tokio::time::sleep;
 use wiremock::matchers::{method, path};
@@ -36,12 +36,9 @@ impl std::fmt::Debug for WorkerWorld {
 #[given("a queued comment request")]
 async fn queued_request(world: &mut WorkerWorld) {
     let dir = TempDir::new().expect("tempdir");
-    let cfg = Arc::new(Config {
-        github_token: "t".into(),
-        socket_path: dir.path().join("sock"),
-        queue_path: dir.path().join("q"),
-        cooldown_period_seconds: 0,
-    });
+    let mut cfg = temp_config(&dir);
+    cfg.cooldown_period_seconds = 0;
+    let cfg = Arc::new(cfg);
     let (mut sender, receiver) = channel(&cfg.queue_path).expect("channel");
     let req = CommentRequest {
         owner: "o".into(),
@@ -83,14 +80,7 @@ async fn worker_runs(world: &mut WorkerWorld) {
     let cfg = world.cfg.as_ref().unwrap().clone();
     let rx = world.receiver.take().unwrap();
     let server = world.server.as_ref().unwrap();
-    let octocrab = Arc::new(
-        Octocrab::builder()
-            .personal_token("t".to_string())
-            .base_uri(server.uri())
-            .expect("base_uri")
-            .build()
-            .expect("build octocrab"),
-    );
+    let octocrab = octocrab_for(server);
     let handle = tokio::spawn(async move {
         let _ = run_worker(cfg, rx, octocrab).await;
     });

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,0 +1,3 @@
+//! Test utility modules.
+
+pub mod test_helpers;

--- a/tests/util/test_helpers.rs
+++ b/tests/util/test_helpers.rs
@@ -1,0 +1,59 @@
+//! Helper utilities for behavioural and unit tests.
+//!
+//! These functions create temporary daemon configuration objects and
+//! Octocrab clients tailored for a `wiremock::MockServer`.
+#![allow(clippy::expect_used, reason = "simplify test helper setup")]
+
+use std::sync::Arc;
+
+use comenqd::config::Config;
+use octocrab::Octocrab;
+use tempfile::TempDir;
+use wiremock::MockServer;
+
+/// Build a temporary [`Config`] using paths under `tmp`.
+///
+/// # Examples
+///
+/// ```
+/// use tempfile::tempdir;
+/// use comenqd::config::Config;
+/// use comenq_lib::tests::util::test_helpers::temp_config;
+///
+/// let dir = tempdir().unwrap();
+/// let cfg: Config = temp_config(&dir);
+/// assert!(cfg.socket_path.ends_with("sock"));
+/// ```
+pub fn temp_config(tmp: &TempDir) -> Config {
+    Config {
+        github_token: String::from("t"),
+        socket_path: tmp.path().join("sock"),
+        queue_path: tmp.path().join("q"),
+        cooldown_period_seconds: 1,
+    }
+}
+
+/// Create an [`Octocrab`] instance configured for `server`.
+///
+/// # Examples
+///
+/// ```
+/// use wiremock::MockServer;
+/// use comenq_lib::tests::util::test_helpers::octocrab_for;
+///
+/// # tokio_test::block_on(async {
+/// let server = MockServer::start().await;
+/// let octocrab = octocrab_for(&server);
+/// assert!(octocrab.base_url().as_str().contains(&server.uri()));
+/// # });
+/// ```
+pub fn octocrab_for(server: &MockServer) -> Arc<Octocrab> {
+    Arc::new(
+        Octocrab::builder()
+            .personal_token("t".to_string())
+            .base_uri(server.uri())
+            .expect("base_uri")
+            .build()
+            .expect("build octocrab"),
+    )
+}

--- a/tests/util/test_helpers.rs
+++ b/tests/util/test_helpers.rs
@@ -2,7 +2,6 @@
 //!
 //! These functions create temporary daemon configuration objects and
 //! Octocrab clients tailored for a `wiremock::MockServer`.
-#![allow(clippy::expect_used, reason = "simplify test helper setup")]
 
 use std::sync::Arc;
 
@@ -18,7 +17,7 @@ use wiremock::MockServer;
 /// ```
 /// use tempfile::tempdir;
 /// use comenqd::config::Config;
-/// use comenq_lib::tests::util::test_helpers::temp_config;
+/// use util::test_helpers::temp_config;
 ///
 /// let dir = tempdir().unwrap();
 /// let cfg: Config = temp_config(&dir);
@@ -39,7 +38,7 @@ pub fn temp_config(tmp: &TempDir) -> Config {
 ///
 /// ```
 /// use wiremock::MockServer;
-/// use comenq_lib::tests::util::test_helpers::octocrab_for;
+/// use util::test_helpers::octocrab_for;
 ///
 /// # tokio_test::block_on(async {
 /// let server = MockServer::start().await;
@@ -47,6 +46,7 @@ pub fn temp_config(tmp: &TempDir) -> Config {
 /// assert!(octocrab.base_url().as_str().contains(&server.uri()));
 /// # });
 /// ```
+#[expect(clippy::expect_used, reason = "simplify test helper setup")]
 pub fn octocrab_for(server: &MockServer) -> Arc<Octocrab> {
     Arc::new(
         Octocrab::builder()


### PR DESCRIPTION
## Summary
- introduce `tests::util::test_helpers` with helpers for test config and Octocrab
- use these helpers in behavioural steps and daemon tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f8080b8c8322a0de3157b874d0d8

## Summary by Sourcery

Introduce reusable test helper utilities and refactor existing tests to leverage them for consistent configuration and Octocrab setup.

New Features:
- Add tests/util/test_helpers module with temp_config and octocrab_for functions for test setup

Enhancements:
- Refactor daemon unit tests and behavioural cucumber steps to use the new test helpers instead of manual setup

Documentation:
- Add documentation comments and examples for the test helper functions

Tests:
- Replace repeated Config and Octocrab construction in daemon and cucumber tests with temp_config and octocrab_for helpers