### PR TITLE
Apply review feedback to packaging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,23 +4,21 @@ builds:
   - id: comenq
     binary: comenq
     main: ./crates/comenq
-    goos: [linux]
-    goarch: [amd64, arm64]
-    builder: go
-    hooks:
-      pre:
-        - cmd: cargo build --release --package comenq --target {{ .TARGET }}
-        - cmd: cp target/{{ .TARGET }}/release/comenq {{ .Path }}
+    builder: rust
+    targets:
+      - x86_64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
   - id: comenqd
     binary: comenqd
     main: ./crates/comenqd
-    goos: [linux]
-    goarch: [amd64, arm64]
-    builder: go
-    hooks:
-      pre:
-        - cmd: cargo build --release --package comenqd --target {{ .TARGET }}
-        - cmd: cp target/{{ .TARGET }}/release/comenqd {{ .Path }}
+    builder: rust
+    targets:
+      - x86_64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
 
 archives:
   - id: default
@@ -29,7 +27,7 @@ archives:
     files:
       - LICENSE
       - README.md
-      - packaging/comenqd/config.toml
+      - packaging/shared/config.toml
 
 nfpms:
   - id: comenq-packages
@@ -54,7 +52,7 @@ nfpms:
     contents:
       - src: packaging/linux/comenqd.service
         dst: /lib/systemd/system/comenqd.service
-      - src: packaging/comenqd/config.toml
+      - src: packaging/shared/config.toml
         dst: /etc/comenq/config.toml
         type: config
     scripts:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,14 @@
 project_name: comenq
 
+plugins:
+  - name: rust
+
 builds:
   - id: comenq
     binary: comenq
     main: ./crates/comenq
     builder: rust
-    targets:
+    targets: &targets
       - x86_64-unknown-linux-gnu
       - aarch64-unknown-linux-gnu
       - x86_64-apple-darwin
@@ -14,11 +17,7 @@ builds:
     binary: comenqd
     main: ./crates/comenqd
     builder: rust
-    targets:
-      - x86_64-unknown-linux-gnu
-      - aarch64-unknown-linux-gnu
-      - x86_64-apple-darwin
-      - aarch64-apple-darwin
+    targets: *targets
 
 archives:
   - id: default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,8 +305,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "comenq-lib",
+ "rstest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,11 @@ dependencies = [
  "cucumber",
  "octocrab",
  "ortho_config",
+ "rstest",
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "test-support",
  "tokio",
@@ -355,6 +357,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
  "yaque",
 ]
 
@@ -2759,6 +2762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,12 +2781,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,13 @@ clap = { workspace = true }
 comenq = { path = "crates/comenq" }
 comenqd = { path = "crates/comenqd" }
 ortho_config = { git = "https://github.com/leynos/ortho-config.git", tag = "v0.4.0" }
-tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
+tempfile = { workspace = true }
 yaque = { workspace = true }
-wiremock = "0.6"
+wiremock = { workspace = true }
 octocrab = { workspace = true }
+serde_yaml = { version = "0.9", default-features = false }
+rstest = { workspace = true }
+serial_test = { workspace = true }
 test-support = { path = "test-support" }
 
 [[test]]
@@ -45,12 +48,15 @@ serde_json = "1.0"
 octocrab = "0.38"
 yaque = "0.6"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 anyhow = "1.0"
 thiserror = "1.0"
 ortho_config = { git = "https://github.com/leynos/ortho-config.git", tag = "v0.4.0" }
-serde_yaml = "0.9"
+rstest = "0.18"
 tempfile = "3.10"
+serial_test = "2"
+wiremock = "0.6"
+serde_yaml = "0.9"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -16,5 +16,5 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.18.0"
-tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
+rstest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -14,3 +14,7 @@ serde_json = { workspace = true }
 comenq-lib = { path = "../.." }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.18.0"
+tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release

--- a/crates/comenq/src/client.rs
+++ b/crates/comenq/src/client.rs
@@ -91,7 +91,6 @@ mod tests {
     use super::{ClientError, parse_slug, run};
     use crate::Args;
     use comenq_lib::CommentRequest;
-    use rstest::rstest;
     use tempfile::tempdir;
     use tokio::io::AsyncReadExt;
     use tokio::net::UnixListener;

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -20,8 +20,9 @@ ortho_config = { workspace = true }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"] }
 
 [dev-dependencies]
-rstest = "0.18.0"
-tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
-serial_test = "2"
+rstest = { workspace = true }
+tempfile = { workspace = true }
+serial_test = { workspace = true }
+wiremock = { workspace = true }
 test-support = { path = "../../test-support" }
 test-utils = { path = "../test-utils" }

--- a/crates/comenqd/src/config.rs
+++ b/crates/comenqd/src/config.rs
@@ -20,7 +20,7 @@ const DEFAULT_QUEUE_PATH: &str = "/var/lib/comenq/queue";
 const DEFAULT_COOLDOWN: u64 = 960;
 
 /// Runtime configuration for the daemon.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Config {
     /// GitHub Personal Access Token.
     pub github_token: String,
@@ -126,7 +126,7 @@ mod tests {
     }
 
     pub mod support {
-        pub use super::env_guard::{EnvVarGuard, remove_env_var, set_env_var};
+        pub use super::env_guard::{EnvVarGuard, remove_env_var};
     }
 
     use support::{EnvVarGuard, remove_env_var};

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -285,7 +285,7 @@ mod tests {
     use test_support::wait_for_file;
     use test_utils::{octocrab_for, temp_config};
     use tokio::io::AsyncWriteExt;
-    use tokio::net::{UnixListener, UnixStream};
+    use tokio::net::UnixStream;
     use tokio::sync::{mpsc, watch};
     use tokio::time::{Duration, sleep};
     use wiremock::matchers::{method, path};
@@ -364,7 +364,7 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let queue_path = dir.path().join("q");
         let (sender, mut receiver) = channel(&queue_path).expect("channel");
-        let (client_tx, mut writer_rx) = mpsc::unbounded_channel();
+        let (client_tx, writer_rx) = mpsc::unbounded_channel();
         let writer = tokio::spawn(queue_writer(sender, writer_rx));
 
         let (mut client, server) = UnixStream::pair().expect("pair");

--- a/crates/comenqd/src/logging.rs
+++ b/crates/comenqd/src/logging.rs
@@ -66,7 +66,9 @@ mod tests {
     #[test]
     fn init_logging() {
         let buf = Arc::new(Mutex::new(Vec::new()));
-        std::env::set_var("RUST_LOG", "info");
+        // Nightly marks `std::env::set_var` as `unsafe`; tests run serially so
+        // using it is acceptable here.
+        unsafe { std::env::set_var("RUST_LOG", "info") };
         init_with_writer(BufMakeWriter { buf: buf.clone() });
         info!("captured");
         let output = String::from_utf8(buf.lock().expect("Failed to lock log buffer").clone())

--- a/docs/automated-cross-platform-packaging.md
+++ b/docs/automated-cross-platform-packaging.md
@@ -234,12 +234,14 @@ systemctl start comenqd.service
 ```bash
 #!/bin/bash
 set -euo pipefail
-# Stop and disable the service before removal.
-if systemctl is-active --quiet comenqd.service; then
-    systemctl stop comenqd.service
-fi
-if systemctl is-enabled --quiet comenqd.service; then
-    systemctl disable comenqd.service
+# Stop and disable the service before removal, only if systemd is present.
+if command -v systemctl >/dev/null && [ -d /run/systemd/system ]; then
+    if systemctl is-active --quiet comenqd.service; then
+        systemctl stop comenqd.service
+    fi
+    if systemctl is-enabled --quiet comenqd.service; then
+        systemctl disable comenqd.service
+    fi
 fi
 ```
 

--- a/docs/automated-cross-platform-packaging.md
+++ b/docs/automated-cross-platform-packaging.md
@@ -406,18 +406,21 @@ archive.
 
 Here is the complete `.goreleaser.yaml` with both Linux and macOS
 configurations. It relies on the `goreleaser-rust` plugin to simplify
-cross-compiling:
+cross-compiling and uses a YAML anchor for the shared target list:
 
 ```yaml
 # .goreleaser.yaml
 project_name: comenq
+
+plugins:
+  - name: rust
 
 builds:
   - id: comenq
     binary: comenq
     main: ./crates/comenq
     builder: rust
-    targets:
+    targets: &targets
       - x86_64-unknown-linux-gnu
       - aarch64-unknown-linux-gnu
       - x86_64-apple-darwin
@@ -426,11 +429,7 @@ builds:
     binary: comenqd
     main: ./crates/comenqd
     builder: rust
-    targets:
-      - x86_64-unknown-linux-gnu
-      - aarch64-unknown-linux-gnu
-      - x86_64-apple-darwin
-      - aarch64-apple-darwin
+    targets: *targets
 
 archives:
   - id: default

--- a/packaging/linux/preremove.sh
+++ b/packaging/linux/preremove.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-if systemctl is-active --quiet comenqd.service; then
-    systemctl stop comenqd.service
-fi
+if command -v systemctl >/dev/null && [ -d /run/systemd/system ]; then
+    if systemctl is-active --quiet comenqd.service; then
+        systemctl stop comenqd.service
+    fi
 
-if systemctl is-enabled --quiet comenqd.service; then
-    systemctl disable comenqd.service
+    if systemctl is-enabled --quiet comenqd.service; then
+        systemctl disable comenqd.service
+    fi
 fi

--- a/packaging/shared/config.toml
+++ b/packaging/shared/config.toml
@@ -1,6 +1,7 @@
 # Default configuration for comenqd
 
-# GitHub Personal Access Token used for authentication
+# GitHub Personal Access Token used for authentication.
+# If left empty, GitHub integration is disabled.
 # github_token = ""
 
 # Minimum log level to output

--- a/tests/support/env_guard.rs
+++ b/tests/support/env_guard.rs
@@ -1,7 +1,7 @@
-// Test helpers for managing environment variables.
-//
-// `EnvVarGuard` temporarily sets an environment variable and restores the
-// previous value on drop.
+//! Test helpers for managing environment variables.
+//!
+//! `EnvVarGuard` temporarily sets an environment variable and restores the
+//! previous value on drop.
 
 #[derive(Debug)]
 pub struct EnvVarGuard {

--- a/tests/support/env_guard.rs
+++ b/tests/support/env_guard.rs
@@ -1,7 +1,7 @@
-//! Test helpers for managing environment variables.
-//!
-//! `EnvVarGuard` temporarily sets an environment variable and restores the
-//! previous value on drop.
+// Test helpers for managing environment variables.
+//
+// `EnvVarGuard` temporarily sets an environment variable and restores the
+// previous value on drop.
 
 #[derive(Debug)]
 pub struct EnvVarGuard {


### PR DESCRIPTION
## Summary
- add systemctl presence check in Linux preremove hook
- clarify that an empty `github_token` disables integration
- adopt the goreleaser-rust plugin and adjust docs accordingly
- move default daemon config to shared directory

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_688bdbaa192c8322996bf4ba6ac23484

## Summary by Sourcery

Apply review feedback to packaging: improve the Linux preremove script, migrate the default config to a shared directory, switch to the goreleaser-rust plugin for builds, and clarify GitHub token behavior.

Bug Fixes:
- Update Linux preremove hook to only run systemctl commands if systemd is present to avoid errors.

Enhancements:
- Adopt goreleaser-rust plugin for cross-platform builds and remove manual build hooks.
- Consolidate default config.toml into packaging/shared and update all packaging references.
- Clarify that leaving github_token empty disables GitHub integration in the default config comments.

Documentation:
- Update automated-cross-platform-packaging documentation and .goreleaser.yaml examples to reflect plugin adoption and shared config location.