### PR TITLE
Fix CodeScene secret check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -29,10 +30,10 @@ jobs:
       - name: Run coverage
         run: cargo tarpaulin --out lcov
       - name: Upload coverage data to CodeScene
-        if: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.1.0
         with:
           format: lcov
-          access-token: ${{ secrets.CS_ACCESS_TOKEN }}
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 


### PR DESCRIPTION
## Summary
- avoid GitHub CI error about undefined `secrets`
- only upload coverage when `CS_ACCESS_TOKEN` is available

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688be01494648322bc097f4e504d4b0a