### PR TITLE
Add wait_for_path helper

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -322,7 +322,10 @@ mod tests {
 
         let handle = tokio::spawn(run(cfg.clone()));
 
-        fs::wait_for_path(&cfg.queue_path, 2000).await;
+        assert!(
+            fs::wait_for_path(&cfg.queue_path, 2000).await,
+            "queue directory not created"
+        );
 
         handle.abort();
         assert!(cfg.queue_path.is_dir(), "queue directory not created");
@@ -386,7 +389,10 @@ mod tests {
 
         let listener_task = tokio::spawn(run_listener(cfg.clone(), client_tx, shutdown_rx));
 
-        fs::wait_for_path(&cfg.socket_path, 100).await;
+        assert!(
+            fs::wait_for_path(&cfg.socket_path, 100).await,
+            "socket file not created"
+        );
 
         let mut stream = UnixStream::connect(&cfg.socket_path)
             .await

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -5,9 +5,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::support::fs::wait_for_path;
 use cucumber::{World, given, then, when};
 use tempfile::TempDir;
-use test_support::wait_for_file;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::sync::{mpsc, watch};
@@ -67,7 +67,7 @@ async fn running_listener(world: &mut ListenerWorld) {
         .expect("config not initialised in ListenerWorld")
         .socket_path;
     assert!(
-        wait_for_file(socket_path, 10, Duration::from_millis(10)).await,
+        wait_for_path(socket_path, 100).await,
         "socket file {} not created within timeout",
         socket_path.display()
     );

--- a/tests/support/fs.rs
+++ b/tests/support/fs.rs
@@ -2,10 +2,22 @@
 use std::path::Path;
 use tokio::time::{Duration, Instant, sleep};
 
-/// Wait for a path to exist within the given timeout.
+/// Wait for a path to appear within the timeout.
 ///
-/// Polls the filesystem every 10ms until `timeout_ms` has elapsed.
-/// Returns `true` if the path appears before the timeout.
+/// The filesystem is polled every 10&nbsp;ms until `timeout_ms` has elapsed.
+/// Returns `true` once the path exists.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::path::Path;
+/// use crate::support::fs::wait_for_path;
+///
+/// # tokio_test::block_on(async move {
+/// let path = Path::new("/tmp/sock");
+/// assert!(wait_for_path(path, 100).await);
+/// # });
+/// ```
 pub async fn wait_for_path(path: &Path, timeout_ms: u64) -> bool {
     let deadline = Instant::now() + Duration::from_millis(timeout_ms);
     while Instant::now() < deadline {

--- a/tests/support/fs.rs
+++ b/tests/support/fs.rs
@@ -1,0 +1,18 @@
+//! Filesystem helpers for tests.
+use std::path::Path;
+use tokio::time::{Duration, Instant, sleep};
+
+/// Wait for a path to exist within the given timeout.
+///
+/// Polls the filesystem every 10ms until `timeout_ms` has elapsed.
+/// Returns `true` if the path appears before the timeout.
+pub async fn wait_for_path(path: &Path, timeout_ms: u64) -> bool {
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    path.exists()
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,4 @@
 //! Support utilities shared by tests.
 
 pub mod env_guard;
+pub mod fs;


### PR DESCRIPTION
## Summary
- add `wait_for_path` to `tests/support`
- use the helper in daemon and cucumber listener tests

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688cb8f8c5d48322a53b348ae9c5962a

## Summary by Sourcery

Add a reusable wait_for_path helper to streamline filesystem polling in tests and refactor existing tests to use it

New Features:
- Add wait_for_path async helper for polling filesystem paths in tests

Enhancements:
- Replace wait_for_file with the new wait_for_path helper in daemon and cucumber listener tests

Tests:
- Introduce tests/support/fs.rs with the wait_for_path implementation and update support mod
- Update daemon and listener tests to include and use the fs module for wait_for_path