### PR TITLE
Add module doc to cucumber test entry

### DIFF
--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,3 +1,8 @@
+//! Cucumber test entry point.
+//!
+//! This module spawns all test worlds concurrently so scenarios run in
+//! parallel.
+
 mod steps;
 mod support;
 mod util;


### PR DESCRIPTION
## Summary
- document cucumber test entry point module

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688d12abad608322aa53d16e07b994cb

## Summary by Sourcery

Enhancements:
- Add module-level documentation to tests/cucumber.rs explaining that test worlds are spawned concurrently for parallel scenario execution