### PR TITLE
Introduce test-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "test-support",
+ "test-utils",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -2452,6 +2453,16 @@ dependencies = [
  "octocrab",
  "tempfile",
  "tokio",
+ "wiremock",
+]
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+dependencies = [
+ "comenqd",
+ "octocrab",
+ "tempfile",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ harness = false
 members = [
     "crates/comenq",
     "crates/comenqd",
+    "crates/test-utils",
     "test-support",
 ]
 resolver = "2"

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -24,3 +24,4 @@ rstest = "0.18.0"
 tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
 serial_test = "2"
 test-support = { path = "../../test-support" }
+test-utils = { path = "../test-utils" }

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -239,14 +239,9 @@ pub async fn run_worker(
 mod tests {
     //! Tests for the daemon tasks.
     use super::*;
-    mod test_helpers {
-        include!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../tests/util/test_helpers.rs"
-        ));
-    }
     use tempfile::tempdir;
-    use test_support::{octocrab_for, temp_config, wait_for_file};
+    use test_support::wait_for_file;
+    use test_utils::{octocrab_for, temp_config};
     use tokio::io::AsyncWriteExt;
     use tokio::net::{UnixListener, UnixStream};
     use tokio::sync::{mpsc, watch};

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-utils"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+comenqd = { path = "../comenqd" }
+octocrab = { workspace = true }
+tempfile = { workspace = true }
+wiremock = "^0.6"

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -1,0 +1,34 @@
+//! Shared test utilities.
+//!
+//! Provides helpers for constructing temporary daemon configuration and
+//! mock Octocrab clients for use with `wiremock` servers.
+
+use std::sync::Arc;
+
+use comenqd::config::Config;
+use octocrab::Octocrab;
+use tempfile::TempDir;
+use wiremock::MockServer;
+
+/// Build a [`Config`] using paths inside `tmp`.
+pub fn temp_config(tmp: &TempDir) -> Config {
+    Config {
+        github_token: String::from("t"),
+        socket_path: tmp.path().join("sock"),
+        queue_path: tmp.path().join("q"),
+        cooldown_period_seconds: 1,
+    }
+}
+
+/// Construct an [`Octocrab`] client for a [`MockServer`].
+#[expect(clippy::expect_used, reason = "simplify test helper setup")]
+pub fn octocrab_for(server: &MockServer) -> Arc<Octocrab> {
+    Arc::new(
+        Octocrab::builder()
+            .personal_token("t".to_string())
+            .base_uri(server.uri())
+            .expect("base_uri")
+            .build()
+            .expect("build octocrab"),
+    )
+}


### PR DESCRIPTION
## Summary
- add new `test-utils` crate to share test helpers
- reference `test-utils` in `comenqd` dev-dependencies
- import helpers directly in daemon tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d12f4271483229cc2cd3a0ff2e959

## Summary by Sourcery

Introduce a new test-utils crate for sharing common test helpers and update comendqd tests and configurations to use it

New Features:
- Introduce test-utils crate containing shared test utilities for temp_config and octocrab_for

Enhancements:
- Remove inline test helper definitions in the daemon tests and switch to importing from test-utils

Build:
- Add test-utils to the workspace members and reference it in comendqd dev-dependencies

Tests:
- Update comendqd tests to import temp_config and octocrab_for directly from test-utils