### PR TITLE
Enable cucumber coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           output-path: lcov.info
           format: lcov
+          with-cucumber-rs: true
+          cucumber-rs-features: tests/features
       - name: Upload coverage data to CodeScene
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # Match semantic version tags (e.g. v1.2.3, v10.11.12, v12.3.7-beta7)
-      - 'v*.*.*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   goreleaser:

--- a/docs/behavioural-testing-in-rust-with-cucumber.md
+++ b/docs/behavioural-testing-in-rust-with-cucumber.md
@@ -1033,15 +1033,24 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
-      - name: Run Cucumber tests and generate JUnit report
-        run: cargo test --test cucumber -- --format junit --out-dir target/junit
-
-      - name: Publish Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # Upload report even if the test step fails
+      - name: Measure coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@c6559452842af6a83b83429129dccaf910e34562
         with:
-          name: junit-test-report
-          path: target/junit/*.xml
+          output-path: lcov.info
+          format: lcov
+          with-cucumber-rs: true
+          cucumber-rs-features: tests/features
+
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: ${{ env.CS_ACCESS_TOKEN }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c6559452842af6a83b83429129dccaf910e34562
+
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 ```
 
 This workflow demonstrates a standard CI setup for a Rust project, including


### PR DESCRIPTION
## Summary
- enable cucumber-rs support on the generate-coverage action
- document coverage step in the behavioural testing guide
- fix release workflow tag pattern to match documentation

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d2768bcf08322a2759da6b6eab0b2

## Summary by Sourcery

Enable coverage measurement for cucumber-rs tests, update documentation and CI workflows to use the shared generate-coverage action with cucumber support, add CodeScene coverage upload, and enforce a stricter version tag pattern in the release workflow

New Features:
- Enable cucumber-rs support in the generate-coverage action

Build:
- Tighten release workflow tag pattern to match numeric semantic versions

CI:
- Include cucumber-rs flags in the generate-coverage action
- Add CodeScene coverage upload step to CI

Documentation:
- Document the coverage step in the behavioural testing guide