### PR TITLE
Fix missing dev deps for client tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,8 +305,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "comenq-lib",
+ "rstest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -14,3 +14,7 @@ serde_json = { workspace = true }
 comenq-lib = { path = "../.." }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.18.0"
+tempfile = { workspace = true }

--- a/tests/steps/release_steps.rs
+++ b/tests/steps/release_steps.rs
@@ -40,8 +40,5 @@ fn triggers_on_tags(world: &mut ReleaseWorld) {
         .expect("tags")
         .as_sequence()
         .expect("sequence");
-    assert!(
-        tags.iter()
-            .any(|t| t.as_str() == Some("v[0-9]*.[0-9]*.[0-9]*"))
-    );
+    assert!(tags.iter().any(|t| t.as_str() == Some("v*.*.*")));
 }


### PR DESCRIPTION
## Summary
- add `rstest` and `tempfile` as dev-dependencies for `crates/comenq`
- update release workflow test to match the new tag glob pattern

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688d2a8678b48322a15112535173d15a

## Summary by Sourcery

Add missing dev-dependencies for crates/comenq and adjust the release workflow test tag pattern

Bug Fixes:
- Add rstest and tempfile as dev-dependencies for crates/comenq

Enhancements:
- Simplify tag glob pattern in release workflow test from "v[0-9]*.[0-9]*.[0-9]*" to "v*.*.*"