### PR TITLE
Fix CodeScene upload condition in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload coverage data to CodeScene
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
+        if: ${{ secrets.CS_ACCESS_TOKEN }}
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c6559452842af6a83b83429129dccaf910e34562
         with:
           format: lcov


### PR DESCRIPTION
## Summary
- ensure CodeScene coverage upload step evaluates `CS_ACCESS_TOKEN` secret directly

## Testing
- `make fmt`
- `make lint`
- `make test` *(fails: then the workflow triggers on tags)*

------
https://chatgpt.com/codex/tasks/task_e_688dd151f5a08322ba6785da302676e2

## Summary by Sourcery

Bug Fixes:
- Use secrets.CS_ACCESS_TOKEN instead of env.CS_ACCESS_TOKEN in the CI workflow step condition for uploading CodeScene coverage