### PR TITLE
Add missing test dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # Match semantic version tags (e.g. v1.2.3, v10.11.12, v12.3.7-beta7)
-      - 'v*.*.*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   goreleaser:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,8 +305,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "comenq-lib",
+ "rstest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ thiserror = "1.0"
 ortho_config = { git = "https://github.com/leynos/ortho-config.git", tag = "v0.4.0" }
 serde_yaml = "0.9"
 tempfile = "3.10"
+rstest = "0.18.0"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -14,3 +14,7 @@ serde_json = { workspace = true }
 comenq-lib = { path = "../.." }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -20,8 +20,8 @@ ortho_config = { workspace = true }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"] }
 
 [dev-dependencies]
-rstest = "0.18.0"
-tempfile = "3.10" # latest 3.x at time of writing; update as new patch versions release
+rstest = { workspace = true }
+tempfile = { workspace = true } # latest 3.x at time of writing; update as new patch versions release
 serial_test = "2"
 test-support = { path = "../../test-support" }
 test-utils = { path = "../test-utils" }


### PR DESCRIPTION
## Summary
- add missing test-only crates
- restrict release workflow tag pattern to semantic versions

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f70a0262c8322b986691e0fefa63b

## Summary by Sourcery

Add missing test-only dependencies across the workspace and tighten the release workflow tag matching

Enhancements:
- Add missing rstest and tempfile crates as dev-dependencies in workspace manifests

CI:
- Restrict GitHub Actions release workflow tag filter to numeric semantic version patterns