### PR TITLE
Fix test setup sender mutability

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -337,7 +337,7 @@ mod tests {
             cooldown_period_seconds: 0,
             ..temp_config(&dir)
         });
-        let (sender, rx) = channel(&cfg.queue_path).expect("channel");
+        let (mut sender, rx) = channel(&cfg.queue_path).expect("channel");
         let req = CommentRequest {
             owner: "o".into(),
             repo: "r".into(),


### PR DESCRIPTION
## Summary
- fix `setup_run_worker` test helper to mark channel sender mutable

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f8224e8208322bcc20c45837ede5f

## Summary by Sourcery

Tests:
- Mark channel sender as mutable in setup_run_worker test helper