### PR TITLE
Prevent worker from retrying posted comments

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -376,7 +376,7 @@ mod tests {
     }
 
     async fn setup_run_worker(status: u16) -> (MockServer, Arc<Config>, Receiver, Arc<Octocrab>) {
-        let root = tempdir().expect("tempdir").into_path();
+        let root = tempdir().expect("tempdir").keep();
         let cfg = Arc::new(Config {
             github_token: String::from("t"),
             socket_path: root.join("sock"),

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -376,10 +376,12 @@ mod tests {
     }
 
     async fn setup_run_worker(status: u16) -> (MockServer, Arc<Config>, Receiver, Arc<Octocrab>) {
-        let dir = tempdir().expect("tempdir");
+        let root = tempdir().expect("tempdir").into_path();
         let cfg = Arc::new(Config {
+            github_token: String::from("t"),
+            socket_path: root.join("sock"),
+            queue_path: root.join("q"),
             cooldown_period_seconds: 0,
-            ..temp_config(&dir)
         });
         let (mut sender, rx) = channel(&cfg.queue_path).expect("channel");
         let req = CommentRequest {

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -526,7 +526,10 @@ mod tests {
         let (server, cfg, rx, octo) = setup_run_worker(201).await;
         let h = tokio::spawn(run_worker(cfg.clone(), rx, octo));
 
-        let _ = wait_for_empty_queue(&cfg.queue_path).await;
+        assert!(
+            wait_for_empty_queue(&cfg.queue_path).await,
+            "queue never drained"
+        );
 
         h.abort();
         h.await.expect_err("worker cancelled");
@@ -535,7 +538,6 @@ mod tests {
         assert!(!requests.is_empty(), "no requests were sent");
 
         if cfg.queue_path.exists() {
-            let _ = wait_for_empty_queue(&cfg.queue_path).await;
             let files = queue_file_count(&cfg.queue_path);
             assert_eq!(files, 0, "queue directory not empty");
         }


### PR DESCRIPTION
## Summary
- avoid requeue loops by treating Octocrab parse errors as success
- enforce a minimum cooldown to throttle retry pace

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f93780fe083228c0aab345359fc30

## Summary by Sourcery

Prevent endless retry loops and throttle retry pace when posting comments to GitHub

Bug Fixes:
- Treat Octocrab JSON/Serde parse errors as success so failed deserialisations don’t trigger retries

Enhancements:
- Enforce a minimum one-second cooldown between retry attempts to avoid busy looping