### PR TITLE
Keep TempDir alive for worker tests

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -331,7 +331,9 @@ mod tests {
         path.exists()
     }
 
-    async fn setup_run_worker(status: u16) -> (MockServer, Arc<Config>, Receiver, Arc<Octocrab>) {
+    async fn setup_run_worker(
+        status: u16,
+    ) -> (MockServer, Arc<Config>, Receiver, Arc<Octocrab>, TempDir) {
         let dir = tempdir().expect("tempdir");
         let cfg = Arc::new(Config {
             // Use a positive cooldown to ensure retries are throttled.
@@ -363,7 +365,7 @@ mod tests {
             .await;
 
         let octo = octocrab_for(&server);
-        (server, cfg, rx, octo)
+        (server, cfg, rx, octo, dir)
     }
 
     #[tokio::test]
@@ -457,7 +459,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_worker_commits_on_success() {
-        let (server, cfg, rx, octo) = setup_run_worker(201).await;
+        let (server, cfg, rx, octo, _dir) = setup_run_worker(201).await;
         let h = tokio::spawn(run_worker(cfg.clone(), rx, octo));
         sleep(Duration::from_millis(50)).await;
         h.abort();
@@ -467,7 +469,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_worker_requeues_on_error() {
-        let (server, cfg, rx, octo) = setup_run_worker(500).await;
+        let (server, cfg, rx, octo, _dir) = setup_run_worker(500).await;
         let h = tokio::spawn(run_worker(cfg.clone(), rx, octo));
         sleep(Duration::from_millis(50)).await;
         h.abort();

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -282,6 +282,7 @@ mod tests {
     //! Tests for the daemon tasks.
     use super::*;
     use octocrab::Octocrab;
+    use rstest::{fixture, rstest};
     use std::fs as stdfs;
     use std::path::Path;
     use std::sync::Arc;
@@ -331,9 +332,18 @@ mod tests {
         path.exists()
     }
 
-    async fn setup_run_worker(
-        status: u16,
-    ) -> (MockServer, Arc<Config>, Receiver, Arc<Octocrab>, TempDir) {
+    /// Context dependencies for worker tests.
+    struct WorkerTestContext {
+        server: MockServer,
+        cfg: Arc<Config>,
+        rx: Receiver,
+        octo: Arc<Octocrab>,
+        // Hold the directory to ensure temporary paths remain valid.
+        _dir: TempDir,
+    }
+
+    #[fixture]
+    async fn worker_test_context(#[default(201)] status: u16) -> WorkerTestContext {
         let dir = tempdir().expect("tempdir");
         let cfg = Arc::new(Config {
             // Use a positive cooldown to ensure retries are throttled.
@@ -365,7 +375,14 @@ mod tests {
             .await;
 
         let octo = octocrab_for(&server);
-        (server, cfg, rx, octo, dir)
+
+        WorkerTestContext {
+            server,
+            cfg,
+            rx,
+            octo,
+            _dir: dir,
+        }
     }
 
     #[tokio::test]
@@ -457,23 +474,58 @@ mod tests {
         drop(writer);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn run_worker_commits_on_success() {
-        let (server, cfg, rx, octo, _dir) = setup_run_worker(201).await;
-        let h = tokio::spawn(run_worker(cfg.clone(), rx, octo));
+    async fn run_worker_commits_on_success(
+        #[future]
+        #[from(worker_test_context)]
+        ctx: WorkerTestContext,
+    ) {
+        let ctx = ctx.await;
+        let h = tokio::spawn(run_worker(ctx.cfg.clone(), ctx.rx, ctx.octo));
         sleep(Duration::from_millis(50)).await;
         h.abort();
-        assert_eq!(server.received_requests().await.unwrap().len(), 1);
-        assert_eq!(std::fs::read_dir(&cfg.queue_path).unwrap().count(), 0);
+        assert_eq!(
+            ctx.server
+                .received_requests()
+                .await
+                .expect("requests")
+                .len(),
+            1
+        );
+        assert_eq!(
+            stdfs::read_dir(&ctx.cfg.queue_path)
+                .expect("queue_path")
+                .count(),
+            0
+        );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn run_worker_requeues_on_error() {
-        let (server, cfg, rx, octo, _dir) = setup_run_worker(500).await;
-        let h = tokio::spawn(run_worker(cfg.clone(), rx, octo));
+    async fn run_worker_requeues_on_error(
+        #[future]
+        #[with(500)]
+        #[from(worker_test_context)]
+        ctx: WorkerTestContext,
+    ) {
+        let ctx = ctx.await;
+        let h = tokio::spawn(run_worker(ctx.cfg.clone(), ctx.rx, ctx.octo));
         sleep(Duration::from_millis(50)).await;
         h.abort();
-        assert_eq!(server.received_requests().await.unwrap().len(), 1);
-        assert!(std::fs::read_dir(&cfg.queue_path).unwrap().count() > 0);
+        assert_eq!(
+            ctx.server
+                .received_requests()
+                .await
+                .expect("requests")
+                .len(),
+            1
+        );
+        assert!(
+            stdfs::read_dir(&ctx.cfg.queue_path)
+                .expect("queue_path")
+                .count()
+                > 0
+        );
     }
 }

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -495,7 +495,7 @@ mod tests {
         );
         assert_eq!(
             stdfs::read_dir(&ctx.cfg.queue_path)
-                .expect("queue_path")
+                .expect("read queue directory")
                 .count(),
             0
         );
@@ -523,7 +523,7 @@ mod tests {
         );
         assert!(
             stdfs::read_dir(&ctx.cfg.queue_path)
-                .expect("queue_path")
+                .expect("read queue directory")
                 .count()
                 > 0
         );


### PR DESCRIPTION
## Summary
- return `TempDir` from `setup_run_worker`
- bind temp directories in worker tests so they persist for the test duration

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689118c28f5c83229d679373befa8a6e

## Summary by Sourcery

Return TempDir from setup_run_worker to ensure temporary directories persist during worker tests

Enhancements:
- Persist TempDir for the duration of worker tests by returning it from setup_run_worker

Tests:
- Update setup_run_worker signature to include TempDir in the return tuple
- Adjust existing worker tests to bind the returned TempDir to a variable