### PR TITLE
Use expect when reading queue directory in worker tests

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -462,7 +462,12 @@ mod tests {
         sleep(Duration::from_millis(50)).await;
         h.abort();
         assert_eq!(server.received_requests().await.unwrap().len(), 1);
-        assert_eq!(std::fs::read_dir(&cfg.queue_path).unwrap().count(), 0);
+        assert_eq!(
+            std::fs::read_dir(&cfg.queue_path)
+                .expect("read queue directory")
+                .count(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -472,6 +477,11 @@ mod tests {
         sleep(Duration::from_millis(50)).await;
         h.abort();
         assert_eq!(server.received_requests().await.unwrap().len(), 1);
-        assert!(std::fs::read_dir(&cfg.queue_path).unwrap().count() > 0);
+        assert!(
+            std::fs::read_dir(&cfg.queue_path)
+                .expect("read queue directory")
+                .count()
+                > 0
+        );
     }
 }


### PR DESCRIPTION
## Summary
- use `expect` instead of `unwrap` when reading queue directory in `run_worker` tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689118c3d6c08322b4059170d1e750ff

## Summary by Sourcery

Enhancements:
- Use expect("read queue directory") instead of unwrap when reading queue directory in run_worker tests