### PR TITLE
Fix Homebrew config path in packaging docs

### DIFF
--- a/docs/automated-cross-platform-packaging.md
+++ b/docs/automated-cross-platform-packaging.md
@@ -280,15 +280,15 @@ brews:
       bin.install "comenq"
       bin.install "comenqd"
       (etc/"comenqd").mkpath
-      etc.install "config.toml" => "comenqd/config.toml"
+      etc.install "packaging/config/comenqd.toml" => "comenqd/config.toml"
       (var/"log/comenq").mkpath
 ```
 
 #### Step 3: Add the macOS Configuration File
 
-The Homebrew formula will also install a default configuration. Since the same
-settings apply on both platforms, the shared `packaging/config/comenqd.toml` is
-sufficient and will be picked up by the archive.
+The Homebrew formula also installs a default configuration. The file lives at
+`packaging/config/comenqd.toml`, so the `install` section must reference this
+path to place the configuration in `etc`.
 
 #### Step 4: Final `.goreleaser.yaml`
 
@@ -384,7 +384,7 @@ brews:
       bin.install "comenq"
       bin.install "comenqd"
       (etc/"comenqd").mkpath
-      etc.install "config.toml" => "comenqd/config.toml"
+      etc.install "packaging/config/comenqd.toml" => "comenqd/config.toml"
       (var/"log/comenq").mkpath
 
 release:

--- a/docs/automated-cross-platform-packaging.md
+++ b/docs/automated-cross-platform-packaging.md
@@ -280,7 +280,6 @@ brews:
       bin.install "comenq"
       bin.install "comenqd"
       (etc/"comenqd").mkpath
-      etc.install "packaging/config/comenqd.toml" => "comenqd/config.toml"
       (var/"log/comenq").mkpath
 ```
 


### PR DESCRIPTION
## Summary
- clarify Homebrew formula config path

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6890eb7b94948322b97bd9652fb8d491

## Summary by Sourcery

Correct the Homebrew formula configuration path in the packaging documentation to reference the actual location of the default config file.

Documentation:
- Update formula install commands in examples to use packaging/config/comenqd.toml instead of config.toml
- Clarify in the documentation that the default Homebrew config file lives at packaging/config/comenqd.toml and must be referenced in the install section