### PR TITLE
Add coverage test target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+coverage/
 target/
 **/*.rs.bk

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ release: target/release/$(APP) ## Build release binary
 
 all: release ## Default target builds release binary
 
-clean: ## Remove build artifacts
+clean: ## Remove build artefacts
 	$(CARGO) clean
+	rm -rf coverage
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
 MDLINT ?= markdownlint
 NIXIE ?= nixie
-COV_MIN ?= 0
+COV_MIN ?= 0 # Minimum line coverage percentage for coverage targets
 
 define CHECK_CARGO_LLVM_COV
 	@command -v cargo-llvm-cov >/dev/null || { \
@@ -28,11 +28,11 @@ clean: ## Remove build artefacts
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
 
-test-cov: ## Run tests with coverage; set COV_MIN to enforce a threshold
+test-cov: ## Run workspace-wide tests with coverage; set COV_MIN to enforce a threshold
 	$(CHECK_CARGO_LLVM_COV)
 	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --summary-only --text --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 
-test-cov-lcov: ## Run tests with coverage and write LCOV to coverage/lcov.info
+test-cov-lcov: ## Run workspace-wide tests with coverage and write LCOV to coverage/lcov.info
 	$(CHECK_CARGO_LLVM_COV)
 	mkdir -p coverage
 	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test test-cov build release lint fmt check-fmt markdownlint nixie
 
 APP ?= comenq
 CARGO ?= cargo
@@ -17,6 +17,9 @@ clean: ## Remove build artifacts
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+
+test-cov: ## Run tests with coverage and print report
+	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --all-features --summary-only --text $(BUILD_JOBS)
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ MDLINT ?= markdownlint
 NIXIE ?= nixie
 COV_MIN ?= 0
 
+define CHECK_CARGO_LLVM_COV
+	@command -v cargo-llvm-cov >/dev/null || { \
+	echo "error: cargo-llvm-cov not found. Install with: cargo install cargo-llvm-cov"; \
+	exit 127; \
+	}
+endef
+
 build: target/debug/$(APP) ## Build debug binary
 release: target/release/$(APP) ## Build release binary
 
@@ -15,23 +22,18 @@ all: release ## Default target builds release binary
 
 clean: ## Remove build artefacts
 	$(CARGO) clean
+	@command -v cargo-llvm-cov >/dev/null && $(CARGO) llvm-cov clean --workspace || true
 	rm -rf coverage
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
 
-test-cov: ## Run tests with coverage and print report
-	@command -v cargo-llvm-cov >/dev/null || { \
-	  echo "error: cargo-llvm-cov not found. Install with: cargo install cargo-llvm-cov"; \
-	  exit 127; \
-	}
+test-cov: ## Run tests with coverage; set COV_MIN to enforce a threshold
+	$(CHECK_CARGO_LLVM_COV)
 	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --summary-only --text --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 
 test-cov-lcov: ## Run tests with coverage and write LCOV to coverage/lcov.info
-	@command -v cargo-llvm-cov >/dev/null || { \
-	  echo "error: cargo-llvm-cov not found. Install with: cargo install cargo-llvm-cov"; \
-	  exit 127; \
-	}
+	$(CHECK_CARGO_LLVM_COV)
 	mkdir -p coverage
 	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Comenq
 
 Comenq is a fault-tolerant service that queues GitHub Pull Request comments. It
-follows a daemon\-client model: the `comenqd` daemon enforces a 16\-minute
-cooling\-off period for posting, while the `comenq` CLI simply enqueues
+follows a daemon-client model: the `comenqd` daemon enforces a 16-minute
+cooling-off period for posting, while the `comenq` CLI simply enqueues
 requests. The architecture and crate choices are described in
 [docs/comenq-design.md](docs/comenq-design.md). Further guides in the
 [`docs/`](docs/) directory detail testing approaches and library rationale.
@@ -15,6 +15,9 @@ Use the provided `make` targets to manage the project:
 - `make release` &ndash; produce optimized release binaries
 - `make test` &ndash; execute the full test suite
 - `make test-cov` &ndash; run tests with coverage and print a text report
+  (fails if line coverage drops below `COV_MIN`)
+- `make test-cov-lcov` &ndash; run tests with coverage and write
+  `coverage/lcov.info`
 - `make lint` &ndash; run Clippy with warnings denied
 - `make fmt` &ndash; format Rust and Markdown files
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ requests. The architecture and crate choices are described in
 Use the provided `make` targets to manage the project:
 
 - `make build` &ndash; compile debug binaries in `target/debug/`
-- `make release` &ndash; produce optimized release binaries
+- `make release` &ndash; produce optimised release binaries
 - `make test` &ndash; execute the full test suite
-- `make test-cov` &ndash; run tests with coverage and print a text report
-  (fails if line coverage drops below `COV_MIN`)
+- `make test-cov` &ndash; run tests with coverage and print a text report.
+  Pass `COV_MIN=75` to fail if line coverage drops below 75%
 - `make test-cov-lcov` &ndash; run tests with coverage and write
-  `coverage/lcov.info`
+  `coverage/lcov.info`. Also honours `COV_MIN`
 - `make lint` &ndash; run Clippy with warnings denied
 - `make fmt` &ndash; format Rust and Markdown files
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Use the provided `make` targets to manage the project:
 - `make build` &ndash; compile debug binaries in `target/debug/`
 - `make release` &ndash; produce optimized release binaries
 - `make test` &ndash; execute the full test suite
+- `make test-cov` &ndash; run tests with coverage and print a text report
 - `make lint` &ndash; run Clippy with warnings denied
 - `make fmt` &ndash; format Rust and Markdown files
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Use the provided `make` targets to manage the project:
 - `make build` &ndash; compile debug binaries in `target/debug/`
 - `make release` &ndash; produce optimised release binaries
 - `make test` &ndash; execute the full test suite
-- `make test-cov` &ndash; run tests with coverage and print a text report.
-  Pass `COV_MIN=75` to fail if line coverage drops below 75%
-- `make test-cov-lcov` &ndash; run tests with coverage and write
+- `make test-cov` &ndash; run workspace-wide tests with coverage and print a
+  text report. Set `COV_MIN=75` to fail if line coverage drops below 75%
+- `make test-cov-lcov` &ndash; run workspace-wide tests with coverage and write
   `coverage/lcov.info`. Also honours `COV_MIN`
 - `make lint` &ndash; run Clippy with warnings denied
 - `make fmt` &ndash; format Rust and Markdown files

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-07-22"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
## Summary
- add `llvm-tools-preview` component to rust toolchain so `llvm-cov` is available for coverage

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make test-cov`


------
https://chatgpt.com/codex/tasks/task_e_6896894df8688322a7ffc33660fb44de

## Summary by Sourcery

Introduce a coverage test target by adding llvm-tools-preview to the Rust toolchain and updating the Makefile and documentation to support running tests with coverage

New Features:
- Add test-cov Makefile target to run tests with coverage and print a text report

Enhancements:
- Include llvm-tools-preview component in rust-toolchain.toml for llvm-cov support

Documentation:
- Document the test-cov target in README.md