### PR TITLE
Avoid clone in config conversion test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 **/*.rs.bk
+**/*~
+.crush/

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/comenqd/src/config.rs
+++ b/crates/comenqd/src/config.rs
@@ -86,7 +86,12 @@ impl From<test_support::daemon::TestConfig> for Config {
 #[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 impl From<&test_support::daemon::TestConfig> for Config {
     fn from(value: &test_support::daemon::TestConfig) -> Self {
-        Self::from(value.clone())
+        Self {
+            github_token: value.github_token.clone(),
+            socket_path: value.socket_path.clone(),
+            queue_path: value.queue_path.clone(),
+            cooldown_period_seconds: value.cooldown_period_seconds,
+        }
     }
 }
 

--- a/crates/comenqd/src/config.rs
+++ b/crates/comenqd/src/config.rs
@@ -64,7 +64,9 @@ impl From<test_support::daemon::TestConfig> for Config {
 
 /// Convert a borrowed [`test_support::daemon::TestConfig`] into a [`Config`].
 ///
-/// Requires the `test-support` feature and delegates to the owned conversion.
+/// Requires the `test-support` feature and clones only the owned fields,
+/// avoiding an intermediate allocation of a full
+/// [`test_support::daemon::TestConfig`] clone.
 ///
 /// # Examples
 ///
@@ -269,13 +271,15 @@ mod tests {
 
     #[cfg(feature = "test-support")]
     #[rstest]
+    #[case(|cfg: &test_support::daemon::TestConfig| Config::from(cfg))]
+    #[case(|cfg: &test_support::daemon::TestConfig| Config::from(cfg.clone()))]
     #[serial_test::serial]
-    fn converts_from_test_config() {
+    fn converts_from_test_config(#[case] conv: fn(&test_support::daemon::TestConfig) -> Config) {
         use test_support::temp_config;
 
         let tmp = tempdir().expect("create tempdir");
         let test_cfg = temp_config(&tmp).with_cooldown(42);
-        let cfg = Config::from(&test_cfg);
+        let cfg = conv(&test_cfg);
 
         assert_eq!(cfg.github_token, test_cfg.github_token);
         assert_eq!(cfg.socket_path, test_cfg.socket_path);

--- a/crates/comenqd/src/config.rs
+++ b/crates/comenqd/src/config.rs
@@ -270,7 +270,7 @@ mod tests {
 
         let tmp = tempdir().expect("create tempdir");
         let test_cfg = temp_config(&tmp).with_cooldown(42);
-        let cfg = Config::from(test_cfg.clone());
+        let cfg = Config::from(&test_cfg);
 
         assert_eq!(cfg.github_token, test_cfg.github_token);
         assert_eq!(cfg.socket_path, test_cfg.socket_path);


### PR DESCRIPTION
## Summary
- avoid cloning `TestConfig` when converting to `Config`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689792a0d1a483229ac07ffd5e2e0713

## Summary by Sourcery

Avoid unnecessary cloning of `TestConfig` in the config conversion test by passing it by reference

Enhancements:
- remove unnecessary clone in config conversion test

Tests:
- pass TestConfig by reference instead of cloning in Config conversion test