### PR TITLE
Include doctests in coverage targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-cov: ## Run workspace-wide tests with coverage; set COV_MIN to enforce a th
 test-cov-lcov: ## Run workspace-wide tests with coverage and write LCOV to coverage/lcov.info
 	$(CHECK_CARGO_LLVM_COV)
 	mkdir -p coverage
-        RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --doctests --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --doctests --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ test: ## Run tests with warnings treated as errors
 
 test-cov: ## Run workspace-wide tests with coverage; set COV_MIN to enforce a threshold
 	$(CHECK_CARGO_LLVM_COV)
-	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --summary-only --text --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
+        RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --doctests --summary-only --text --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 
 test-cov-lcov: ## Run workspace-wide tests with coverage and write LCOV to coverage/lcov.info
 	$(CHECK_CARGO_LLVM_COV)
 	mkdir -p coverage
-	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
+        RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --doctests --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: ## Run tests with warnings treated as errors
 
 test-cov: ## Run workspace-wide tests with coverage; set COV_MIN to enforce a threshold
 	$(CHECK_CARGO_LLVM_COV)
-        RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --doctests --summary-only --text --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --workspace --all-features --doctests --summary-only --text --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 
 test-cov-lcov: ## Run workspace-wide tests with coverage and write LCOV to coverage/lcov.info
 	$(CHECK_CARGO_LLVM_COV)


### PR DESCRIPTION
## Summary
- include doctest runs in `test-cov` coverage checks
- collect doctest coverage in `test-cov-lcov` outputs

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689cd9916ec483229b5144153746c36f

## Summary by Sourcery

Add the --doctests flag to both test-cov and test-cov-lcov Makefile targets to ensure doctests are included in coverage reports

Enhancements:
- Include doctest runs in the workspace-wide coverage checks
- Collect doctest coverage in the LCOV output for the test-cov-lcov target