### PR TITLE
Check llvm-tools-preview component for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,14 @@ NIXIE ?= nixie
 COV_MIN ?= 0 # Minimum line coverage percentage for coverage targets
 
 define CHECK_CARGO_LLVM_COV
-	@command -v cargo-llvm-cov >/dev/null || { \
-	echo "error: cargo-llvm-cov not found. Install with: cargo install cargo-llvm-cov"; \
-	exit 127; \
-	}
+        @command -v cargo-llvm-cov >/dev/null || { \
+        echo "error: cargo-llvm-cov not found. Install with: cargo install cargo-llvm-cov"; \
+        exit 127; \
+        }
+        @rustup component list --installed | grep -q '^llvm-tools-preview' >/dev/null || { \
+        echo "error: rustup component llvm-tools-preview not found. Install with: rustup component add llvm-tools-preview"; \
+        exit 127; \
+        }
 endef
 
 build: target/debug/$(APP) ## Build debug binary


### PR DESCRIPTION
## Summary
- verify rustup llvm-tools-preview component before coverage run

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cd9a6cd388322b071444114a09b8d