### PR TITLE
Expand worker test polling

### DIFF
--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = { workspace = true }
 comenq-lib = { path = "../.." }
 ortho_config = { workspace = true }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"] }
-test-support = { workspace = true, optional = true }
+test-support = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
@@ -28,5 +28,4 @@ wiremock = { workspace = true }
 
 [features]
 default = []
-# Enable helpers from the `test-support` crate for integration tests.
-test-support = ["dep:test-support"]
+test-support = []

--- a/crates/comenqd/src/config.rs
+++ b/crates/comenqd/src/config.rs
@@ -50,7 +50,6 @@ pub struct Config {
 /// assert_eq!(cfg.cooldown_period_seconds, 1);
 /// ```
 #[cfg(feature = "test-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 impl From<test_support::daemon::TestConfig> for Config {
     fn from(value: test_support::daemon::TestConfig) -> Self {
         Self {
@@ -85,7 +84,6 @@ impl From<test_support::daemon::TestConfig> for Config {
 /// assert_eq!(cfg.queue_path, test_cfg.queue_path);
 /// ```
 #[cfg(feature = "test-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 impl From<&test_support::daemon::TestConfig> for Config {
     fn from(value: &test_support::daemon::TestConfig) -> Self {
         Self {

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -143,7 +143,10 @@ pub async fn run(config: Config) -> Result<()> {
         },
     }
     let _ = shutdown_tx.send(());
-    tokio::time::timeout(Duration::from_secs(30), worker.shutdown()).await??;
+    match tokio::time::timeout(Duration::from_secs(30), worker.shutdown()).await {
+        Ok(res) => res?,
+        Err(_) => tracing::warn!("worker shutdown timed out"),
+    }
     writer.await??;
     Ok(())
 }

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -332,7 +332,13 @@ async fn worker_loop(
     loop {
         tokio::select! {
             res = rx.recv() => {
-                let guard = res?;
+                let guard = match res {
+                    Ok(g) => g,
+                    Err(e) => {
+                        tracing::info!(error = %e, "Worker receiver closed; exiting");
+                        return Err(e.into());
+                    }
+                };
                 if let Some((ref enq, _)) = signals {
                     let _ = enq.send(*enq.borrow() + 1);
                 }

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -898,7 +898,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tracing::{error, info, warn};
 use yaque::{channel, Receiver, Sender};
 use comenq_lib::CommentRequest;

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -963,15 +963,15 @@ async fn main() -> Result<()> {
         _ = tokio::signal::ctrl_c() => {
             info!("Shutdown signal received; attempting graceful shutdown...");
             let _ = shutdown_tx.send(());
-            match timeout(Duration::from_secs(10), worker.shutdown()).await {
+            match timeout(Duration::from_secs(30), worker.shutdown()).await {
                 Ok(res) => {
                     if let Err(e) = res {
                         error!("Worker shutdown failed: {e}");
                     }
                 }
                 Err(_) => {
-                    error!("Worker shutdown timed out");
-                    return Err(anyhow::anyhow!("Worker shutdown timed out"));
+                    error!("Worker shutdown timed out after 30 seconds; possible resource leak or deadlock");
+                    return Err(anyhow::anyhow!("Worker shutdown timed out after 30 seconds"));
                 }
             }
             // Ensure the worker task has fully terminated.

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -971,6 +971,10 @@ async fn main() -> Result<()> {
                 }
                 Err(_) => warn!("Worker shutdown timed out"),
             }
+            // Ensure the worker task has fully terminated.
+            if let Err(e) = worker.join_handle().await {
+                error!("Worker join failed: {e}");
+            }
         }
     }
 

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -969,7 +969,10 @@ async fn main() -> Result<()> {
                         error!("Worker shutdown failed: {e}");
                     }
                 }
-                Err(_) => warn!("Worker shutdown timed out"),
+                Err(_) => {
+                    error!("Worker shutdown timed out");
+                    return Err(anyhow::anyhow!("Worker shutdown timed out"));
+                }
             }
             // Ensure the worker task has fully terminated.
             if let Err(e) = worker.join_handle().await {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,7 +60,7 @@
 
 ## Milestone 5: `comenqd` Daemon — Queue Worker Task
 
-- [x] Implement the `run_worker` async task.
+- [x] Implement the worker task for processing queue items.
 
 - [x] Initialize the `octocrab` client with the GitHub PAT from the
   configuration.

--- a/tests/steps/worker_steps.rs
+++ b/tests/steps/worker_steps.rs
@@ -96,8 +96,13 @@ async fn worker_runs(world: &mut WorkerWorld) {
     let server = world.server.as_ref().expect("server should be initialised");
     let octocrab = octocrab_for(server);
     let (worker, mut signals) = Worker::spawn_with_signals(cfg, rx, octocrab);
-    let _ = timeout(Duration::from_secs(30), signals.on_enqueued()).await;
-    worker.shutdown().await.expect("shutdown");
+    timeout(Duration::from_secs(30), signals.on_enqueued())
+        .await
+        .expect("worker did not start processing");
+    timeout(Duration::from_secs(30), worker.shutdown())
+        .await
+        .expect("worker shutdown timed out")
+        .expect("shutdown");
 }
 
 #[then("the comment is posted")]

--- a/tests/steps/worker_steps.rs
+++ b/tests/steps/worker_steps.rs
@@ -95,7 +95,7 @@ async fn worker_runs(world: &mut WorkerWorld) {
         .expect("receiver should be initialised");
     let server = world.server.as_ref().expect("server should be initialised");
     let octocrab = octocrab_for(server);
-    let (worker, mut signals) = Worker::spawn_with_signals(cfg, rx, octocrab);
+    let (worker, signals) = Worker::spawn_with_signals(cfg, rx, octocrab);
     timeout(Duration::from_secs(30), signals.on_enqueued())
         .await
         .expect("worker did not start processing");


### PR DESCRIPTION
## Summary
- expose `Worker` hooks to signal queue progress and graceful shutdown
- update worker tests and docs to use hooks instead of polling
- document worker task in roadmap

## Testing
- `make fmt`
- `make lint`
- `make test`
- `PATH="$PATH:/root/.cargo/bin" make test-cov`

------
https://chatgpt.com/codex/tasks/task_e_689fd242805c83229ab2705e743df1a1

## Summary by Sourcery

Introduces a structured Worker API with progress signals and graceful shutdown, updates the daemon main and test suite to leverage the new hooks instead of manual polling, and aligns documentation and roadmap with these changes.

New Features:
- Add Worker struct encapsulating queue processing with spawn, spawn_with_signals, and shutdown methods
- Expose WorkerSignals hooks (on_enqueued and on_drained) for awaiting queue progress events

Enhancements:
- Update daemon run function to use the new Worker API and handle ctrl-c graceful shutdown
- Replace polling utilities in worker tests with WorkerSignals-based synchronization

Documentation:
- Update design documentation to describe the Worker API and signal channels
- Revise roadmap to reflect the updated worker task implementation

Tests:
- Refactor worker tests to use spawn_with_signals and on_enqueued/on_drained instead of poll_until
- Remove manual polling helpers and adjust fixtures to support multiple queued items