### PR TITLE
Restart daemon tasks on failure

### DIFF
--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -375,6 +375,10 @@ requests even while the worker task is in its long sleep phase. A request can
 be accepted and enqueued in milliseconds, while the worker task independently
 processes the queue at its own deliberate pace.
 
+Both tasks are supervised. If either exits unexpectedly the daemon logs the
+failure and restarts the task, preserving service availability without relying
+on an external process supervisor.
+
 ### 3.2. The Persistent Job Queue with `yaque`
 
 A core requirement for the daemon is fault tolerance. If the daemon or the


### PR DESCRIPTION
## Summary
- Supervise listener and worker tasks and restart them on failure to keep daemon alive
- Document supervision strategy in architecture design

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`

closes #7

------
https://chatgpt.com/codex/tasks/task_e_68a4a757786c832288519a94b9511adf

## Summary by Sourcery

Implement supervision of listener and worker tasks to automatically restart them on failure

New Features:
- Supervise and restart listener and worker daemon tasks upon unexpected exit

Documentation:
- Document the task supervision strategy in the architecture design

Tests:
- Add tests to verify supervisor restarts failed listener and worker tasks