### PR TITLE
Fix comendqd listener tests

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -5,3 +5,12 @@
 pub use crate::listener::run_listener;
 pub use crate::supervisor::{SupervisorError as DaemonError, ensure_queue_dir, queue_writer, run};
 pub use crate::worker::{WorkerControl, WorkerHooks, run_worker};
+
+/// Listener utilities for accepting client connections.
+///
+/// Re-exports functions from the internal `listener` module so integration tests
+/// can exercise socket preparation and client handling without exposing the
+/// entire module as part of the public API.
+pub mod listener {
+    pub use crate::listener::{handle_client, prepare_listener, run_listener};
+}


### PR DESCRIPTION
## Summary
- re-export listener helpers through daemon module
- clean up tests and resolve join handle type issues

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aba351365083228743e86bc31eb806