### PR TITLE
Use RepoSlug for repository arguments

### DIFF
--- a/crates/comenq/src/client.rs
+++ b/crates/comenq/src/client.rs
@@ -21,9 +21,6 @@ pub enum ClientError {
     /// Serializing the request failed.
     #[error("failed to serialize request: {0}")]
     Serialize(#[from] serde_json::Error),
-    /// The repository slug was invalid.
-    #[error("invalid repository format")]
-    BadSlug,
     /// Writing the request to the socket failed.
     #[error("failed to write to daemon: {0}")]
     Write(#[source] std::io::Error),
@@ -41,7 +38,7 @@ pub enum ClientError {
 /// # use std::path::PathBuf;
 /// # async fn try_run() -> Result<(), comenq::ClientError> {
 /// let args = Args {
-///     repo_slug: "owner/repo".into(),
+///     repo_slug: "owner/repo".parse().expect("slug"),
 ///     pr_number: 1,
 ///     comment_body: String::from("Hi"),
 ///     socket: PathBuf::from("/run/comenq/socket"),
@@ -51,13 +48,9 @@ pub enum ClientError {
 /// # }
 /// ```
 pub async fn run(args: Args) -> Result<(), ClientError> {
-    if crate::validate_repo_slug(&args.repo_slug).is_err() {
-        return Err(ClientError::BadSlug);
-    }
-    let (owner, repo) = parse_slug(&args.repo_slug);
     let request = CommentRequest {
-        owner,
-        repo,
+        owner: args.repo_slug.owner.clone(),
+        repo: args.repo_slug.repo.clone(),
         pr_number: args.pr_number,
         body: args.comment_body,
     };
@@ -78,18 +71,10 @@ pub async fn run(args: Args) -> Result<(), ClientError> {
     Ok(())
 }
 
-fn parse_slug(slug: &str) -> (String, String) {
-    // safe expect: `validate_repo_slug` ensures two non-empty parts
-    let (owner, repo) = slug
-        .split_once('/')
-        .expect("slug should have been validated by validate_repo_slug");
-    (owner.to_owned(), repo.to_owned())
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ClientError, parse_slug, run};
-    use crate::Args;
+    use super::{ClientError, run};
+    use crate::{Args, RepoSlug};
     use comenq_lib::CommentRequest;
     use tempfile::tempdir;
     use tokio::io::AsyncReadExt;
@@ -109,7 +94,7 @@ mod tests {
         });
 
         let args = Args {
-            repo_slug: "octocat/hello-world".into(),
+            repo_slug: "octocat/hello-world".parse().expect("slug"),
             pr_number: 1,
             comment_body: "Hi".into(),
             socket: socket.clone(),
@@ -129,7 +114,7 @@ mod tests {
         let socket = dir.path().join("nosock");
 
         let args = Args {
-            repo_slug: "octocat/hello-world".into(),
+            repo_slug: "octocat/hello-world".parse().expect("slug"),
             pr_number: 1,
             comment_body: "Hi".into(),
             socket: socket.clone(),
@@ -139,27 +124,10 @@ mod tests {
         assert!(matches!(err, ClientError::Connect(_)));
     }
 
-    #[tokio::test]
-    async fn run_errors_on_bad_slug() {
-        let dir = tempdir().expect("temp dir");
-        let socket = dir.path().join("sock");
-        let _listener = UnixListener::bind(&socket).expect("bind socket");
-
-        let args = Args {
-            repo_slug: "badslug".into(),
-            pr_number: 1,
-            comment_body: "Hi".into(),
-            socket,
-        };
-
-        let err = run(args).await.expect_err("should error");
-        assert!(matches!(err, ClientError::BadSlug));
-    }
-
     #[test]
-    fn slug_is_split() {
-        let (owner, repo) = parse_slug("octocat/hello-world");
-        assert_eq!(owner, "octocat");
-        assert_eq!(repo, "hello-world");
+    fn slug_parses() {
+        let slug: RepoSlug = "octocat/hello-world".parse().expect("slug");
+        assert_eq!(slug.owner, "octocat");
+        assert_eq!(slug.repo, "hello-world");
     }
 }

--- a/crates/comenq/src/lib.rs
+++ b/crates/comenq/src/lib.rs
@@ -1,19 +1,45 @@
 //! Library utilities for the `comenq` CLI.
 
 use clap::Parser;
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 mod client;
 
 pub use client::{ClientError, run};
+
+/// A GitHub repository slug in `owner/repo` format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoSlug {
+    /// Repository owner.
+    pub owner: String,
+    /// Repository name.
+    pub repo: String,
+}
+
+impl FromStr for RepoSlug {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Perform the split once to avoid redundant parsing elsewhere.
+        let (owner, repo) = s
+            .split_once('/')
+            .ok_or_else(|| String::from("invalid repository format, use 'owner/repo'"))?;
+        if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+            return Err(String::from("invalid repository format, use 'owner/repo'"));
+        }
+        Ok(Self {
+            owner: owner.to_owned(),
+            repo: repo.to_owned(),
+        })
+    }
+}
 
 /// Command line arguments for the `comenq` client.
 #[derive(Debug, Clone, Parser)]
 #[command(name = "comenq", about = "Enqueue a GitHub PR comment")]
 pub struct Args {
     /// The repository in 'owner/repo' format (e.g., "rust-lang/rust").
-    #[arg(value_parser = validate_repo_slug)]
-    pub repo_slug: String,
+    pub repo_slug: RepoSlug,
 
     /// The pull request number to comment on.
     pub pr_number: u64,
@@ -26,18 +52,9 @@ pub struct Args {
     pub socket: PathBuf,
 }
 
-fn validate_repo_slug(s: &str) -> Result<String, String> {
-    let parts: Vec<&str> = s.split('/').collect();
-    if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-        Ok(s.to_owned())
-    } else {
-        Err(String::from("invalid repository format, use 'owner/repo'"))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::Args;
+    use super::{Args, RepoSlug};
     use clap::Parser;
     use rstest::rstest;
 
@@ -47,7 +64,8 @@ mod tests {
         let pr_str = pr.to_string();
         let args = Args::try_parse_from(["comenq", slug, &pr_str, body]);
         let args = args.expect("valid arguments should parse");
-        assert_eq!(args.repo_slug, slug);
+        let expected: RepoSlug = slug.parse().expect("slug parses");
+        assert_eq!(args.repo_slug, expected);
         assert_eq!(args.pr_number, pr);
         assert_eq!(args.comment_body, body);
     }

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -147,6 +147,7 @@ be the core of the `comenq` client's `main.rs`.
 
 use clap::Parser;
 use std::path::PathBuf;
+use comenq::RepoSlug;
 
 /// A CLI client to enqueue a comment for a GitHub Pull Request.
 #
@@ -154,7 +155,7 @@ use std::path::PathBuf;
 pub struct Args {
     /// The repository in 'owner/repo' format (e.g., "rust-lang/rust").
     #
-    repo_slug: String,
+    repo_slug: RepoSlug,
 
     /// The pull request number to comment on.
     #
@@ -254,6 +255,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 
 use tracing::warn;
+use comenq::RepoSlug;
 
 // Assume CommentRequest is in a shared library: `use comenq_lib::CommentRequest;`
 // For this example, we define it here.
@@ -273,7 +275,7 @@ pub struct CommentRequest {
 pub struct Args {
     /// The repository in 'owner/repo' format (e.g., "rust-lang/rust").
     #
-    repo_slug: String,
+    repo_slug: RepoSlug,
 
     /// The pull request number to comment on.
     #
@@ -293,27 +295,16 @@ async fn main() {
     // 1. Parse command-line arguments using clap's derive macro.
     let args = Args::parse();
 
-    // 2. Validate and parse the 'owner/repo' slug.
-    let (owner, repo) = args
-        .repo_slug
-        .split_once('/')
-        .expect("validated by clap value parser");
-    let owner = owner.to_string();
-    let repo = repo.to_string();
-
-    // Using a custom value parser keeps the error handling within `clap`
-    // itself, providing immediate feedback if the slug is malformed.
-
-
-    // 3. Construct the request payload.
+    // 2. Construct the request payload. The slug has already been validated
+    //    and split by `clap`.
     let request = CommentRequest {
-        owner,
-        repo,
+        owner: args.repo_slug.owner.clone(),
+        repo: args.repo_slug.repo.clone(),
         pr_number: args.pr_number,
         body: args.comment_body,
     };
 
-    // 4. Serialize the request to JSON.
+    // 3. Serialize the request to JSON.
     let payload = match serde_json::to_vec(&request) {
         Ok(p) => p,
         Err(e) => {
@@ -357,9 +348,8 @@ resides in a dedicated `client` module to keep the argument parser focused. The
 binary parses the CLI arguments and delegates to `run`, allowing the test suite
 to exercise the network code directly. Any failures to serialize the request or
 communicate with the daemon are surfaced via a small `ClientError` enumeration.
-The `run` function also verifies the repository slug at runtime to guard
-against misuse in other contexts. An invalid slug results in a `BadSlug`
-variant, keeping the code panic free while still surfacing helpful errors.
+The repository slug is converted into a structured `RepoSlug` during argument
+handling, so `run` operates on validated data without rechecking it.
 
 ## Section 3: Design of the `comenqd` Daemon
 
@@ -909,12 +899,13 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use comenq_lib::CommentRequest; // Using the shared library
 use tracing::warn;
+use comenq::RepoSlug;
 
 #
 #
 struct Args {
     #
-    repo_slug: String,
+    repo_slug: RepoSlug,
     #
     pr_number: u64,
     #
@@ -927,16 +918,9 @@ struct Args {
 async fn main() {
     let args = Args::parse();
 
-    let (owner, repo) = args
-        .repo_slug
-        .split_once('/')
-        .expect("validated by clap value parser");
-    let owner = owner.to_string();
-    let repo = repo.to_string();
-
     let request = CommentRequest {
-        owner,
-        repo,
+        owner: args.repo_slug.owner.clone(),
+        repo: args.repo_slug.repo.clone(),
         pr_number: args.pr_number,
         body: args.comment_body,
     };

--- a/tests/features/client_main.feature
+++ b/tests/features/client_main.feature
@@ -12,10 +12,3 @@ Feature: Client main function
     Given no daemon is listening on a socket
     When the client sends the request
     Then an error occurs
-
-  @edge_case
-  Scenario: invalid repository slug
-    Given a dummy daemon listening on a socket
-    And the arguments contain an invalid slug
-    When the client sends the request
-    Then a slug error occurs

--- a/tests/steps/client_main_steps.rs
+++ b/tests/steps/client_main_steps.rs
@@ -33,7 +33,7 @@ fn dummy_daemon(world: &mut ClientWorld) {
     });
 
     world.args = Some(Args {
-        repo_slug: "octocat/hello-world".into(),
+        repo_slug: "octocat/hello-world".parse().expect("slug"),
         pr_number: 1,
         comment_body: "Hi".into(),
         socket: socket.clone(),
@@ -47,7 +47,7 @@ fn no_daemon(world: &mut ClientWorld) {
     let dir = TempDir::new().expect("tempdir");
     let socket = dir.path().join("sock");
     world.args = Some(Args {
-        repo_slug: "octocat/hello-world".into(),
+        repo_slug: "octocat/hello-world".parse().expect("slug"),
         pr_number: 1,
         comment_body: "Hi".into(),
         socket,
@@ -77,21 +77,6 @@ async fn daemon_receives(world: &mut ClientWorld) {
 fn an_error_occurs(world: &mut ClientWorld) {
     match world.result.take() {
         Some(Err(ClientError::Connect(_))) => {}
-        other => panic!("unexpected result: {other:?}"),
-    }
-}
-
-#[given("the arguments contain an invalid slug")]
-fn invalid_slug(world: &mut ClientWorld) {
-    if let Some(args) = &mut world.args {
-        args.repo_slug = "bad".into();
-    }
-}
-
-#[then("a slug error occurs")]
-fn slug_error_occurs(world: &mut ClientWorld) {
-    match world.result.take() {
-        Some(Err(ClientError::BadSlug)) => {}
         other => panic!("unexpected result: {other:?}"),
     }
 }


### PR DESCRIPTION
## Summary
- parse repository slugs into a RepoSlug struct to validate format once
- use RepoSlug in CLI Args and client run logic
- drop redundant slug validation and update documentation

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68acabc628508322b95fc5fa0e3f9625