### PR TITLE
Refactor daemon entrypoint for library reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +380,7 @@ dependencies = [
  "anyhow",
  "backon",
  "clap",
+ "color-eyre",
  "comenq-lib",
  "figment",
  "octocrab",
@@ -609,6 +637,16 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1175,6 +1213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1695,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "parking_lot"
@@ -2457,7 +2507,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2770,6 +2820,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,7 +3073,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,13 @@ tokio = { version = "1.35", features = ["full"] }
 clap = { version = "4.4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-octocrab = "0.38"
-yaque = "0.6"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-anyhow = "1.0"
-thiserror = "1.0"
+  octocrab = "0.38"
+  yaque = "0.6"
+  tracing = "0.1"
+  tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+  anyhow = "1.0"
+  color-eyre = "0.6"
+  thiserror = "1.0"
 ortho_config = { git = "https://github.com/leynos/ortho-config.git", tag = "v0.4.0" }
 serde_yaml = "0.9"
 tempfile = "3.10"

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -15,6 +15,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+color-eyre = { workspace = true }
 comenq-lib = { path = "../.." }
 ortho_config = { workspace = true }
 figment = { version = "0.10", default-features = false, features = ["env", "toml"] }

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = { workspace = true } # latest 3.x at time of writing; update as new p
 serial_test = "2"
 wiremock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+test-support = { workspace = true }
 
 [features]
 default = []

--- a/crates/comenqd/src/main.rs
+++ b/crates/comenqd/src/main.rs
@@ -4,19 +4,23 @@
 
 use tracing::info;
 
+use color_eyre::eyre::Context;
 use comenqd::{config::Config, daemon};
 
 mod logging;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> color_eyre::Result<()> {
     logging::init();
+    color_eyre::install()?;
     let cfg = Config::load()?;
     info!(
         socket = ?cfg.socket_path,
         queue = ?cfg.queue_path,
         "Comenqd daemon started"
     );
-    daemon::run(cfg).await?;
+    daemon::run(cfg)
+        .await
+        .context("daemon exited unexpectedly")?;
     Ok(())
 }

--- a/crates/comenqd/src/main.rs
+++ b/crates/comenqd/src/main.rs
@@ -4,20 +4,19 @@
 
 use tracing::info;
 
-mod logging;
+use comenqd::{config::Config, daemon};
 
-mod config;
-mod daemon;
-mod listener;
-mod supervisor;
-mod worker;
-use config::Config;
-use daemon::run;
+mod logging;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     logging::init();
     let cfg = Config::load()?;
-    info!(socket = ?cfg.socket_path, queue = ?cfg.queue_path, "Comenqd daemon started");
-    run(cfg).await
+    info!(
+        socket = ?cfg.socket_path,
+        queue = ?cfg.queue_path,
+        "Comenqd daemon started"
+    );
+    daemon::run(cfg).await?;
+    Ok(())
 }

--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -41,6 +41,9 @@ async fn wait_for_file(path: &Path, tries: u32, delay: Duration) -> bool {
 
 #[tokio::test]
 async fn ensure_queue_dir_creates_directory() {
+    // Touch the `Simple` variant to satisfy dead code detection in modules that
+    // do not exercise it directly.
+    let _ = TestComplexity::Simple;
     let dir = tempdir().expect("Failed to create temporary directory");
     let path = dir.path().join("queue");
     comenqd::daemon::ensure_queue_dir(&path)
@@ -124,7 +127,7 @@ async fn run_listener_accepts_connections() -> Result<(), String> {
     assert_eq!(stored, req);
     let _ = shutdown_tx.send(());
     let timeout = TimeoutConfig::new(10, TestComplexity::Moderate).calculate_timeout();
-    let listener_res = tokio::time::timeout(timeout, listener_task.await)
+    let listener_res = tokio::time::timeout(timeout, listener_task)
         .await
         .expect("listener join timeout");
     match listener_res {

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -10,6 +10,7 @@ pub const CI_MULTIPLIER: u64 = 2;
 pub const PROGRESSIVE_RETRY_PERCENTS: [u64; 3] = [50, 100, 150];
 
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Variants are exercised selectively by tests
 pub enum TestComplexity {
     Simple,
     Moderate,


### PR DESCRIPTION
## Summary
- simplify daemon binary to reuse library modules
- fix daemon tests to avoid spurious dead code warnings and join handle misuse

## Testing
- `make fmt`
- `make lint`
- `make test`
- `cargo llvm-cov --workspace --summary-only --lcov --output-path lcov.info` *(fails: worker_tests::run_worker_commits_on_success, worker_tests::run_worker_requeues_on_error)*

------
https://chatgpt.com/codex/tasks/task_e_68ace7d3909c83229b330c28ba2dd6c1

## Summary by Sourcery

Refactor the daemon entrypoint to delegate to shared library modules and enhance test reliability

Enhancements:
- Simplify daemon binary by delegating execution to the library’s `daemon::run` and consolidating config import

Tests:
- Reference `TestComplexity::Simple` in daemon tests to suppress dead code warnings
- Apply timeout directly to the listener test's join handle to correct misuse