### PR TITLE
Refactor join error mapping in daemon tests

### DIFF
--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -25,7 +25,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 use yaque::{Receiver, channel};
 
-use util::{TestComplexity, TimeoutConfig, timeout_with_retries};
+use util::{TestComplexity, TimeoutConfig, join_err, timeout_with_retries};
 
 const TEST_COOLDOWN_SECONDS: u64 = 1;
 
@@ -60,15 +60,6 @@ async fn wait_for_file(path: &Path, tries: u32, delay: Duration) -> bool {
         sleep(delay).await;
     }
     path.exists()
-}
-
-/// Convert a `JoinError` into a concise diagnostic message for the given task.
-fn join_err(name: &str, e: tokio::task::JoinError) -> String {
-    if e.is_panic() {
-        format!("{name} task panicked")
-    } else {
-        format!("{name} task failed: {e}")
-    }
 }
 
 #[tokio::test]
@@ -182,7 +173,7 @@ async fn run_listener_accepts_connections() -> Result<(), String> {
         Err(e) => return Err(join_err("listener", e)),
     }
     match writer_handle.await {
-        Ok(_receiver) => {}
+        Ok(_) => {}
         Err(e) => return Err(join_err("writer", e)),
     }
     Ok(())

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -13,6 +13,7 @@ pub const PROGRESSIVE_RETRY_PERCENTS: [u64; 3] = [50, 100, 150];
 
 #[derive(Debug, Clone, Copy)]
 pub enum TestComplexity {
+    #[expect(dead_code, reason = "Constructed in integration tests but unused here")]
     Simple,
     Moderate,
     Complex,

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -12,10 +12,6 @@ pub const CI_MULTIPLIER: u64 = 2;
 pub const PROGRESSIVE_RETRY_PERCENTS: [u64; 3] = [50, 100, 150];
 
 #[derive(Debug, Clone, Copy)]
-#[expect(
-    dead_code,
-    reason = "Test-only enum; variants are exercised selectively across modules"
-)]
 pub enum TestComplexity {
     Simple,
     Moderate,


### PR DESCRIPTION
## Summary
- reuse a join error helper to make daemon tests consistent

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aef09eeb0c8322ad6b416337b7fc53

## Summary by Sourcery

Extract join_err helper to centralize JoinError formatting and update daemon tests to use it for consistent error mapping across listener, writer, and worker tasks

Enhancements:
- Abstract JoinError formatting into join_err helper function

Tests:
- Replace inline JoinError mapping with join_err helper in listener, writer, and worker tests