### PR TITLE
Replace cucumber-rs with rstest-bdd for CLI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +369,9 @@ dependencies = [
  "octocrab",
  "ortho_config",
  "regex",
+ "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -688,6 +697,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +935,11 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1848,6 +1868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2043,33 @@ dependencies = [
  "futures-timer",
  "rstest_macros",
  "rustc_version",
+]
+
+[[package]]
+name = "rstest-bdd"
+version = "0.1.0-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961934a0f0d8cea81cb38b8259001eed66e7069c21dbe250168c7122ffe93495"
+dependencies = [
+ "gherkin",
+ "hashbrown 0.15.4",
+ "inventory",
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rstest-bdd-macros"
+version = "0.1.0-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede34e572310674dfb203be72ca0849ca944716ae594ceae661cb3576e3fa1e"
+dependencies = [
+ "gherkin",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ octocrab = { workspace = true }
 test-support = { workspace = true }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
+rstest = { workspace = true }
+rstest-bdd = "0.1.0-alpha2"
+rstest-bdd-macros = "0.1.0-alpha2"
 
 [[test]]
 name = "cucumber"

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -135,6 +135,74 @@ verbatim. The `#[scenario]` macro binds the test function to the first scenario
 in the specified feature file and runs all registered steps before executing
 the body of `test_add_to_basket`.
 
+## Encapsulating BDD State with `rstest-bdd` Fixtures
+
+To modernise step definitions and avoid thread-local state, rely on `rstest`
+fixtures for per-scenario data. This section outlines an approach that mirrors
+`rstest` conventions while keeping steps reusable.
+
+### 1. Use `rstest` fixtures instead of a global world state
+
+Define a fixture representing the scenario state rather than a static or
+thread-local "world". Each scenario receives a fresh instance, ensuring
+isolation and preventing test interference.
+
+- Example: `#[fixture] fn cli_state() -> CliState { ... }`.
+
+### 2. Inject state into steps with `#[from]` attributes
+
+Include a parameter annotated with `#[from(cli_state)]` in each step to access
+the fixture. Use `&mut` when the step modifies the state and `&` when it only
+reads it.
+
+```rust
+#[given("CLI arguments with repo slug \"{slug}\"")]
+fn cli_args_with_repo_slug(#[from(cli_state)] state: &mut CliState, slug: String) {
+    state.args = Some(vec![/* ...slug... */]);
+}
+
+#[then("parsing succeeds")]
+fn parsing_succeeds(#[from(cli_state)] state: &CliState) {
+    assert!(state.result.as_ref().unwrap().is_ok());
+}
+```
+
+### 3. Ensure per-scenario isolation and reset
+
+Attach the fixture to each scenario with `#[with(cli_state)]`. `rstest-bdd`
+inserts the value into the step context before running the steps, so state is
+never shared between tests.
+
+```rust
+#[scenario(path = "features/cli_parser.feature", index = 0)]
+fn cli_valid_args_succeeds(#[with(cli_state)] _: CliState) {}
+```
+
+### 4. Leverage RAII for setup and cleanup
+
+Because fixtures are ordinary Rust values, use their constructors for setup and
+their `Drop` implementations for teardown. When the scenario ends, the fixture
+is dropped automatically, removing the need for manual cleanup.
+
+### 5. Reuse step definitions across modules
+
+Step functions registered with `#[given]`, `#[when]` and `#[then]` are
+available globally. Organise them by domain but avoid duplication; a single
+definition can serve multiple scenarios as long as it uses the appropriate
+fixture.
+
+### 6. Consider parallel execution and step dependencies
+
+Scenario tests run in parallel by default. Isolation via fixtures means steps
+do not clash across scenarios. Within a scenario, steps execute sequentially,
+so design them assuming the `Given–When–Then` order.
+
+### 7. Write idiomatic, reusable step functions
+
+Let fixture injection handle context so steps focus on behaviour. Use
+meaningful fixture names and combine `#[scenario]` with other `rstest`
+features, such as parameterisation, to keep tests concise and expressive.
+
 ## Binding tests to scenarios
 
 The `#[scenario]` macro is the entry point that ties a Rust test function to a

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -137,12 +137,12 @@ the body of `test_add_to_basket`.
 
 ## Encapsulating BDD State with `rstest-bdd` Fixtures
 
-Use `rstest` fixtures for per-scenario data instead of a thread-local world.
-Inject the fixture into steps with `#[from]`, marking it `&mut` when mutation
-is required. Bind the fixture to scenarios using `#[with(cli_state)]` so each
-test receives a fresh instance. Fixtures can implement `Drop` for automatic
-cleanup, and the `inventory` registry keeps step functions reusable across
-modules.
+Use `rstest` fixtures for per-scenario data instead of a thread-local world,
+for example `#[fixture] fn cli_state() -> CliState { … }`. Inject the fixture
+into steps with `#[from]`, marking it `&mut` when mutation is required. Bind
+the fixture to scenarios using `#[with(cli_state)]` so each test receives a
+fresh instance. Fixtures can implement `Drop` for automatic cleanup, and the
+`inventory` registry keeps step functions reusable across modules.
 
 ## Binding tests to scenarios
 

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -199,9 +199,9 @@ so design them assuming the `Given–When–Then` order.
 
 ### 7. Write idiomatic, reusable step functions
 
-Let fixture injection handle context so steps focus on behaviour. Use
-meaningful fixture names and combine `#[scenario]` with other `rstest`
-features, such as parameterization, to keep tests concise and expressive.
+ Let fixture injection handle context, so steps focus on behaviour. Use
+ meaningful fixture names and combine `#[scenario]` with other `rstest`
+ features, such as parameterization, to keep tests concise and expressive.
 
 ## Binding tests to scenarios
 

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -137,7 +137,7 @@ the body of `test_add_to_basket`.
 
 ## Encapsulating BDD State with `rstest-bdd` Fixtures
 
-To modernise step definitions and avoid thread-local state, rely on `rstest`
+To modernize step definitions and avoid thread-local state, rely on `rstest`
 fixtures for per-scenario data. This section outlines an approach that mirrors
 `rstest` conventions while keeping steps reusable.
 
@@ -187,7 +187,7 @@ is dropped automatically, removing the need for manual cleanup.
 ### 5. Reuse step definitions across modules
 
 Step functions registered with `#[given]`, `#[when]` and `#[then]` are
-available globally. Organise them by domain but avoid duplication; a single
+available globally. Organize them by domain but avoid duplication; a single
 definition can serve multiple scenarios as long as it uses the appropriate
 fixture.
 
@@ -201,7 +201,7 @@ so design them assuming the `Given–When–Then` order.
 
 Let fixture injection handle context so steps focus on behaviour. Use
 meaningful fixture names and combine `#[scenario]` with other `rstest`
-features, such as parameterisation, to keep tests concise and expressive.
+features, such as parameterization, to keep tests concise and expressive.
 
 ## Binding tests to scenarios
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,13 @@
+//! Behavioural tests for the CLI argument parser.
+//!
+//! This module binds the feature file to the step definitions using
+//! `rstest-bdd`, ensuring each scenario runs with isolated fixtures.
+
 use rstest_bdd_macros::scenario;
 
 #[path = "steps/cli_steps.rs"]
 mod cli_steps;
+use cli_steps::{CliState, cli_state};
 
 #[scenario(path = "tests/features/cli.feature")]
-fn cli_feature() {}
+fn cli_feature(cli_state: CliState) {}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,7 @@
+use rstest_bdd_macros::scenario;
+
+#[path = "steps/cli_steps.rs"]
+mod cli_steps;
+
+#[scenario(path = "tests/features/cli.feature")]
+fn cli_feature() {}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,4 +11,6 @@ use cli_steps::{CliState, cli_state};
 
 /// Execute scenarios from `tests/features/cli.feature`.
 #[scenario(path = "tests/features/cli.feature")]
-fn cli_feature(cli_state: CliState) {}
+fn cli_feature(cli_state: CliState) {
+    let _ = cli_state;
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -9,5 +9,6 @@ use rstest_bdd_macros::scenario;
 mod cli_steps;
 use cli_steps::{CliState, cli_state};
 
+/// Execute scenarios from `tests/features/cli.feature`.
 #[scenario(path = "tests/features/cli.feature")]
 fn cli_feature(cli_state: CliState) {}

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -6,14 +6,13 @@
 mod steps;
 use cucumber::World as _;
 use steps::{
-    CliWorld, ClientWorld, CommentWorld, ConfigWorld, ListenerWorld, PackagingWorld, ReleaseWorld,
+    ClientWorld, CommentWorld, ConfigWorld, ListenerWorld, PackagingWorld, ReleaseWorld,
     WorkerWorld,
 };
 
 #[tokio::main]
 async fn main() {
     tokio::join!(
-        CliWorld::run("tests/features/cli.feature"),
         ReleaseWorld::run("tests/features/release.feature"),
         ClientWorld::run("tests/features/client_main.feature"),
         CommentWorld::run("tests/features/comment_request.feature"),

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -62,7 +62,7 @@ fn no_cli_arguments(#[from(cli_state)] state: &CliState) {
 fn socket_path(#[from(cli_state)] state: &CliState, path: String) {
     let mut args_ref = state.args.borrow_mut();
     let Some(args) = args_ref.as_mut() else {
-        panic!("args must be initialised by a Given step before setting socket path");
+        panic!("args must be initialized by a Given step before setting socket path");
     };
     args.push(OsString::from("--socket"));
     args.push(OsString::from(path));
@@ -70,10 +70,11 @@ fn socket_path(#[from(cli_state)] state: &CliState, path: String) {
 
 #[when("they are parsed")]
 fn they_are_parsed(#[from(cli_state)] state: &CliState) {
-    let Some(args) = state.args.borrow().clone() else {
+    let Some(args) = state.args.borrow_mut().take() else {
         panic!("args should be set by a given step");
     };
-    *state.result.borrow_mut() = Some(Args::try_parse_from(args));
+    *state.result.borrow_mut() = Some(Args::try_parse_from(&args));
+    *state.args.borrow_mut() = Some(args);
 }
 
 #[then("parsing succeeds")]

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -3,7 +3,6 @@
 //! These steps drive scenarios that verify valid and invalid
 //! command line inputs, including the optional `--socket` flag.
 //! They ensure the parser surface behaves as documented.
-#![expect(clippy::expect_used, reason = "simplify test failure output")]
 
 use clap::Parser;
 use rstest::fixture;
@@ -58,19 +57,19 @@ fn no_cli_arguments(#[from(cli_state)] state: &CliState) {
 
 #[given("socket path \"{path}\"")]
 fn socket_path(#[from(cli_state)] state: &CliState, path: String) {
-    if let Some(args) = state.args.borrow_mut().as_mut() {
-        args.push(OsString::from("--socket"));
-        args.push(OsString::from(path));
-    }
+    let mut args_ref = state.args.borrow_mut();
+    let Some(args) = args_ref.as_mut() else {
+        panic!("args must be initialised by a Given step before setting socket path");
+    };
+    args.push(OsString::from("--socket"));
+    args.push(OsString::from(path));
 }
 
 #[when("they are parsed")]
 fn they_are_parsed(#[from(cli_state)] state: &CliState) {
-    let args = state
-        .args
-        .borrow()
-        .clone()
-        .expect("args should be set by a given step");
+    let Some(args) = state.args.borrow().clone() else {
+        panic!("args should be set by a given step");
+    };
     *state.result.borrow_mut() = Some(Args::try_parse_from(args));
 }
 

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -6,6 +6,7 @@
 #![expect(clippy::expect_used, reason = "simplify test failure output")]
 
 use clap::Parser;
+use rstest::fixture;
 use rstest_bdd_macros::{given, then, when};
 use std::cell::RefCell;
 use std::ffi::OsString;
@@ -13,93 +14,88 @@ use std::path::PathBuf;
 
 use comenq::Args;
 
+/// Per-scenario state for CLI parsing tests.
+///
+/// The fixture returned by [`cli_state`] owns the argument vector and parser
+/// result, ensuring each scenario starts with a clean slate and any resources
+/// are dropped at scope exit.
 #[derive(Default)]
-struct CliState {
-    args: Option<Vec<OsString>>,
-    result: Option<Result<Args, clap::Error>>,
+pub struct CliState {
+    args: RefCell<Option<Vec<OsString>>>,
+    result: RefCell<Option<Result<Args, clap::Error>>>,
 }
 
-thread_local! {
-    static STATE: RefCell<CliState> = RefCell::new(CliState::default());
+/// Provide a fresh [`CliState`] for each scenario.
+#[fixture]
+pub fn cli_state() -> CliState {
+    CliState::default()
 }
 
 #[given("valid CLI arguments")]
-fn valid_cli_arguments() {
-    STATE.with(|s| {
-        let mut st = s.borrow_mut();
-        st.args = Some(vec![
-            OsString::from("comenq"),
-            OsString::from("octocat/hello-world"),
-            OsString::from("1"),
-            OsString::from("Hi"),
-        ]);
-    });
+fn valid_cli_arguments(#[from(cli_state)] state: &CliState) {
+    *state.args.borrow_mut() = Some(vec![
+        OsString::from("comenq"),
+        OsString::from("octocat/hello-world"),
+        OsString::from("1"),
+        OsString::from("Hi"),
+    ]);
 }
 
 #[given("CLI arguments with repo slug \"{slug}\"")]
-fn cli_args_with_repo_slug(slug: String) {
-    STATE.with(|s| {
-        let mut st = s.borrow_mut();
-        st.args = Some(vec![
-            OsString::from("comenq"),
-            OsString::from(slug),
-            OsString::from("1"),
-            OsString::from("Hi"),
-        ]);
-    });
+fn cli_args_with_repo_slug(#[from(cli_state)] state: &CliState, slug: String) {
+    *state.args.borrow_mut() = Some(vec![
+        OsString::from("comenq"),
+        OsString::from(slug),
+        OsString::from("1"),
+        OsString::from("Hi"),
+    ]);
 }
 
 #[given("no CLI arguments")]
-fn no_cli_arguments() {
-    STATE.with(|s| {
-        s.borrow_mut().args = Some(vec![OsString::from("comenq")]);
-    });
+fn no_cli_arguments(#[from(cli_state)] state: &CliState) {
+    *state.args.borrow_mut() = Some(vec![OsString::from("comenq")]);
 }
 
 #[given("socket path \"{path}\"")]
-fn socket_path(path: String) {
-    STATE.with(|s| {
-        let mut st = s.borrow_mut();
-        if let Some(args) = st.args.as_mut() {
-            args.push(OsString::from("--socket"));
-            args.push(OsString::from(path));
-        }
-    });
+fn socket_path(#[from(cli_state)] state: &CliState, path: String) {
+    if let Some(args) = state.args.borrow_mut().as_mut() {
+        args.push(OsString::from("--socket"));
+        args.push(OsString::from(path));
+    }
 }
 
 #[when("they are parsed")]
-fn they_are_parsed() {
-    STATE.with(|s| {
-        let mut st = s.borrow_mut();
-        let args = st.args.clone().expect("args should be set by a given step");
-        st.result = Some(Args::try_parse_from(args));
-    });
+fn they_are_parsed(#[from(cli_state)] state: &CliState) {
+    let args = state
+        .args
+        .borrow()
+        .clone()
+        .expect("args should be set by a given step");
+    *state.result.borrow_mut() = Some(Args::try_parse_from(args));
 }
 
 #[then("parsing succeeds")]
-fn parsing_succeeds() {
-    STATE.with(|s| match s.borrow().result.as_ref() {
+fn parsing_succeeds(#[from(cli_state)] state: &CliState) {
+    match state.result.borrow().as_ref() {
         Some(Ok(_)) => {}
         other => panic!("expected success, got {other:?}"),
-    });
+    }
 }
 
 #[then("an error is returned")]
-fn an_error_is_returned() {
-    STATE.with(|s| match s.borrow().result.as_ref() {
+fn an_error_is_returned(#[from(cli_state)] state: &CliState) {
+    match state.result.borrow().as_ref() {
         Some(Err(_)) => {}
         other => panic!("expected error, got {other:?}"),
-    });
+    }
 }
 
 #[then("the socket path is \"{expected}\"")]
-fn the_socket_path_is(expected: String) {
-    STATE.with(|s| {
-        let st = s.borrow();
-        let args = match st.result.as_ref() {
-            Some(Ok(a)) => a,
-            other => panic!("expected parsed args, got {other:?}"),
-        };
-        assert_eq!(args.socket, PathBuf::from(expected));
-    });
+fn the_socket_path_is(#[from(cli_state)] state: &CliState, expected: String) {
+    let binding = state.result.borrow();
+    let args = match binding.as_ref() {
+        Some(Ok(a)) => a,
+        other => panic!("expected parsed args, got {other:?}"),
+    };
+    assert_eq!(args.socket, PathBuf::from(expected));
 }

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -1,87 +1,105 @@
 //! Behavioural test steps for the CLI argument parser.
 //!
-//! These steps drive the Cucumber scenarios that verify valid and
-//! invalid command line inputs, including the optional `--socket`
-//! flag. They ensure the parser surface behaves as documented.
+//! These steps drive scenarios that verify valid and invalid
+//! command line inputs, including the optional `--socket` flag.
+//! They ensure the parser surface behaves as documented.
 #![expect(clippy::expect_used, reason = "simplify test failure output")]
 
 use clap::Parser;
-use cucumber::{World, given, then, when};
+use rstest_bdd_macros::{given, then, when};
+use std::cell::RefCell;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
 use comenq::Args;
 
-#[derive(Debug, Default, World)]
-pub struct CliWorld {
+#[derive(Default)]
+struct CliState {
     args: Option<Vec<OsString>>,
     result: Option<Result<Args, clap::Error>>,
 }
 
-#[given("valid CLI arguments")]
-fn valid_cli_arguments(world: &mut CliWorld) {
-    world.args = Some(vec![
-        OsString::from("comenq"),
-        OsString::from("octocat/hello-world"),
-        OsString::from("1"),
-        OsString::from("Hi"),
-    ]);
+thread_local! {
+    static STATE: RefCell<CliState> = RefCell::new(CliState::default());
 }
 
-#[given(regex = r#"^CLI arguments with repo slug \"(.+)\"$"#)]
-fn cli_args_with_repo_slug(world: &mut CliWorld, slug: String) {
-    world.args = Some(vec![
-        OsString::from("comenq"),
-        OsString::from(slug),
-        OsString::from("1"),
-        OsString::from("Hi"),
-    ]);
+#[given("valid CLI arguments")]
+fn valid_cli_arguments() {
+    STATE.with(|s| {
+        let mut st = s.borrow_mut();
+        st.args = Some(vec![
+            OsString::from("comenq"),
+            OsString::from("octocat/hello-world"),
+            OsString::from("1"),
+            OsString::from("Hi"),
+        ]);
+    });
+}
+
+#[given("CLI arguments with repo slug \"{slug}\"")]
+fn cli_args_with_repo_slug(slug: String) {
+    STATE.with(|s| {
+        let mut st = s.borrow_mut();
+        st.args = Some(vec![
+            OsString::from("comenq"),
+            OsString::from(slug),
+            OsString::from("1"),
+            OsString::from("Hi"),
+        ]);
+    });
 }
 
 #[given("no CLI arguments")]
-fn no_cli_arguments(world: &mut CliWorld) {
-    world.args = Some(vec![OsString::from("comenq")]);
+fn no_cli_arguments() {
+    STATE.with(|s| {
+        s.borrow_mut().args = Some(vec![OsString::from("comenq")]);
+    });
 }
 
-#[given(regex = r#"^socket path \"(.+)\"$"#)]
-fn socket_path(world: &mut CliWorld, path: String) {
-    if let Some(mut args) = world.args.take() {
-        args.push(OsString::from("--socket"));
-        args.push(OsString::from(path));
-        world.args = Some(args);
-    }
+#[given("socket path \"{path}\"")]
+fn socket_path(path: String) {
+    STATE.with(|s| {
+        let mut st = s.borrow_mut();
+        if let Some(args) = st.args.as_mut() {
+            args.push(OsString::from("--socket"));
+            args.push(OsString::from(path));
+        }
+    });
 }
 
 #[when("they are parsed")]
-fn they_are_parsed(world: &mut CliWorld) {
-    let args = world
-        .args
-        .clone()
-        .expect("world.args should be set by a given step");
-    world.result = Some(Args::try_parse_from(args));
+fn they_are_parsed() {
+    STATE.with(|s| {
+        let mut st = s.borrow_mut();
+        let args = st.args.clone().expect("args should be set by a given step");
+        st.result = Some(Args::try_parse_from(args));
+    });
 }
 
 #[then("parsing succeeds")]
-fn parsing_succeeds(world: &mut CliWorld) {
-    match world.result.as_ref() {
+fn parsing_succeeds() {
+    STATE.with(|s| match s.borrow().result.as_ref() {
         Some(Ok(_)) => {}
         other => panic!("expected success, got {other:?}"),
-    }
+    });
 }
 
 #[then("an error is returned")]
-fn an_error_is_returned(world: &mut CliWorld) {
-    match world.result.take() {
+fn an_error_is_returned() {
+    STATE.with(|s| match s.borrow().result.as_ref() {
         Some(Err(_)) => {}
         other => panic!("expected error, got {other:?}"),
-    }
+    });
 }
 
-#[then(regex = r#"^the socket path is \"(.+)\"$"#)]
-fn the_socket_path_is(world: &mut CliWorld, expected: String) {
-    let args = match world.result.take() {
-        Some(Ok(a)) => a,
-        other => panic!("expected parsed args, got {other:?}"),
-    };
-    assert_eq!(args.socket, PathBuf::from(expected));
+#[then("the socket path is \"{expected}\"")]
+fn the_socket_path_is(expected: String) {
+    STATE.with(|s| {
+        let st = s.borrow();
+        let args = match st.result.as_ref() {
+            Some(Ok(a)) => a,
+            other => panic!("expected parsed args, got {other:?}"),
+        };
+        assert_eq!(args.socket, PathBuf::from(expected));
+    });
 }

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -1,8 +1,6 @@
 //! Behavioural test steps for the CLI argument parser.
 //!
-//! These steps drive scenarios that verify valid and invalid
-//! command line inputs, including the optional `--socket` flag.
-//! They ensure the parser surface behaves as documented.
+//! Verify valid and invalid command-line inputs, including the optional `--socket` flag.
 
 use clap::Parser;
 use rstest::fixture;
@@ -73,8 +71,7 @@ fn they_are_parsed(#[from(cli_state)] state: &CliState) {
     let Some(args) = state.args.borrow_mut().take() else {
         panic!("args should be set by a given step");
     };
-    *state.result.borrow_mut() = Some(Args::try_parse_from(&args));
-    *state.args.borrow_mut() = Some(args);
+    *state.result.borrow_mut() = Some(Args::try_parse_from(args));
 }
 
 #[then("parsing succeeds")]
@@ -102,5 +99,11 @@ fn the_socket_path_is(#[from(cli_state)] state: &CliState, expected: PathBuf) {
     };
     let expected = fs::canonicalize(&expected).unwrap_or(expected);
     let actual = fs::canonicalize(&args.socket).unwrap_or_else(|_| args.socket.clone());
-    assert_eq!(actual, expected);
+    assert_eq!(
+        actual,
+        expected,
+        "socket path mismatch: actual={} expected={}",
+        actual.display(),
+        expected.display(),
+    );
 }

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -1,5 +1,3 @@
-pub mod cli_steps;
-pub use cli_steps::CliWorld;
 pub mod client_main_steps;
 pub use client_main_steps::ClientWorld;
 pub mod comment_steps;


### PR DESCRIPTION
## Summary
- use `rstest-bdd` v0.1.0-alpha2 to drive CLI feature scenarios
- drop `CliWorld` from the cucumber test runner
- add standalone rstest-bdd scenario for CLI parsing

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b19dffc88322bafa7a7ce635ca73

## Summary by Sourcery

Switch CLI tests from cucumber-rs to rstest-bdd by removing the Cucmber-based CliWorld runner, refactoring step definitions to use rstest-bdd macros with a thread-local state, updating dependencies, and adding a standalone rstest-bdd scenario for CLI parsing.

Enhancements:
- Refactor CLI test steps to use rstest-bdd macros (given, when, then) and a thread-local CliState instead of the cucumber-rs World
- Remove cucumber-based CLI test runner from the main test harness

Build:
- Add rstest, rstest-bdd, and rstest-bdd-macros dependencies to Cargo.toml

Tests:
- Introduce tests/cli.rs with a rstest-bdd scenario for running the CLI feature
- Drop cucumber-based invocation of the CLI feature in tests/cucumber.rs