### PR TITLE
Document wait_or_shutdown helper

### DIFF
--- a/crates/comenqd/src/worker.rs
+++ b/crates/comenqd/src/worker.rs
@@ -103,11 +103,11 @@ impl WorkerHooks {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
     /// use tokio::sync::watch;
     /// use comenqd::worker::WorkerHooks;
     ///
-    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// # tokio::runtime::Runtime::new().expect("runtime").block_on(async {
     /// let (tx, mut rx) = watch::channel(());
     ///
     /// // Wait for the full second when no shutdown signal is sent.
@@ -115,10 +115,13 @@ impl WorkerHooks {
     ///
     /// // Sending a shutdown signal returns immediately.
     /// let mut rx = tx.subscribe();
-    /// tx.send(()).unwrap();
+    /// tx.send(()).expect("notify shutdown");
     /// WorkerHooks::wait_or_shutdown(60, &mut rx).await;
     /// # });
     /// ```
+    ///
+    /// The function returns after either the timeout or a shutdown signal,
+    /// without indicating which occurred. Passing `secs = 0` returns immediately.
     pub async fn wait_or_shutdown(secs: u64, shutdown: &mut watch::Receiver<()>) {
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(secs)) => {},


### PR DESCRIPTION
## Summary
- document `wait_or_shutdown` with parameters and a simple example

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e4cd07788322bb69b6895799390d

## Summary by Sourcery

Documentation:
- Document WorkerHooks::wait_or_shutdown with parameter descriptions and a code example