### PR TITLE
Add test for idle client read timeout

### DIFF
--- a/crates/comenqd/tests/listener.rs
+++ b/crates/comenqd/tests/listener.rs
@@ -1,4 +1,4 @@
-//! Tests for listener behaviour: verifies idle client read timeout using paused Tokio time.
+//! Tests for listener behaviour. Freezes Tokio time, advances beyond the client read timeout, and asserts idle connections time out.
 
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;

--- a/crates/comenqd/tests/listener.rs
+++ b/crates/comenqd/tests/listener.rs
@@ -1,0 +1,21 @@
+//! Tests for listener behaviour.
+
+use std::time::Duration;
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+use tokio::time::advance;
+
+use comenqd::daemon::listener::handle_client;
+
+#[tokio::test(start_paused = true)]
+async fn handle_client_times_out_if_client_does_not_close() {
+    let (client_tx, _rx) = mpsc::channel(1);
+    let (client, server) = UnixStream::pair().expect("pair");
+    let handle = tokio::spawn(handle_client(server, client_tx));
+
+    advance(Duration::from_secs(6)).await;
+
+    let res = handle.await.expect("join");
+    assert!(res.is_err());
+    drop(client);
+}

--- a/crates/comenqd/tests/listener.rs
+++ b/crates/comenqd/tests/listener.rs
@@ -1,4 +1,5 @@
-//! Tests for listener behaviour. Freezes Tokio time, advances beyond the client read timeout, and asserts idle connections time out.
+//! Tests for listener behaviour. Freezes Tokio time, advances beyond the client
+//! read timeout, and asserts idle connections time out.
 
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;

--- a/crates/comenqd/tests/listener.rs
+++ b/crates/comenqd/tests/listener.rs
@@ -1,21 +1,78 @@
-//! Tests for listener behaviour.
+//! Tests for listener behaviour: verifies idle client read timeout using paused Tokio time.
 
 use std::time::Duration;
+use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
+use tokio::task::yield_now;
 use tokio::time::advance;
 
-use comenqd::daemon::listener::handle_client;
+use comenq_lib::CommentRequest;
+use comenqd::daemon::listener::{CLIENT_READ_TIMEOUT_SECS, MAX_REQUEST_BYTES, handle_client};
 
 #[tokio::test(start_paused = true)]
 async fn handle_client_times_out_if_client_does_not_close() {
     let (client_tx, _rx) = mpsc::channel(1);
     let (client, server) = UnixStream::pair().expect("pair");
     let handle = tokio::spawn(handle_client(server, client_tx));
-
-    advance(Duration::from_secs(6)).await;
-
-    let res = handle.await.expect("join");
-    assert!(res.is_err());
+    // Ensure the handler registers its timeout before advancing time.
+    yield_now().await;
+    advance(Duration::from_secs(CLIENT_READ_TIMEOUT_SECS + 1)).await;
+    let err = handle.await.expect("join").expect_err("expected timeout");
+    assert!(err.to_string().contains("client read timed out"));
     drop(client);
+}
+
+#[tokio::test]
+async fn handle_client_accepts_exact_max_request_bytes() {
+    let (tx, mut rx) = mpsc::channel(1);
+    let (mut client, server) = UnixStream::pair().expect("pair");
+    let handle = tokio::spawn(handle_client(server, tx));
+
+    let base = CommentRequest {
+        owner: String::new(),
+        repo: String::new(),
+        pr_number: 0,
+        body: String::new(),
+    };
+    let base_len = serde_json::to_vec(&base).expect("serialise").len();
+    let body_len = MAX_REQUEST_BYTES - base_len;
+    let mut request = base;
+    request.body = "a".repeat(body_len);
+    let payload = serde_json::to_vec(&request).expect("serialise");
+
+    client.write_all(&payload).await.expect("write");
+    client.shutdown().await.expect("shutdown");
+
+    handle.await.expect("join").expect("handle");
+    let msg = rx.recv().await.expect("recv");
+    assert_eq!(msg, payload);
+}
+
+#[tokio::test]
+async fn handle_client_rejects_request_exceeding_limit() {
+    let (tx, _rx) = mpsc::channel(1);
+    let (mut client, server) = UnixStream::pair().expect("pair");
+    let handle = tokio::spawn(handle_client(server, tx));
+
+    let base = CommentRequest {
+        owner: String::new(),
+        repo: String::new(),
+        pr_number: 0,
+        body: String::new(),
+    };
+    let base_len = serde_json::to_vec(&base).expect("serialise").len();
+    let body_len = MAX_REQUEST_BYTES - base_len + 1;
+    let mut request = base;
+    request.body = "a".repeat(body_len);
+    let payload = serde_json::to_vec(&request).expect("serialise");
+
+    client.write_all(&payload).await.expect("write");
+    client.shutdown().await.expect("shutdown");
+
+    let err = handle
+        .await
+        .expect("join")
+        .expect_err("expected size error");
+    assert!(err.to_string().contains("client payload exceeds"));
 }

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -488,11 +488,11 @@ Its workflow is as follows:
    accepting a new connection, it immediately spawns a new, short-lived `tokio`
    task to handle that specific client.
 
-5. **Handle Client:** This per-client task reads up to 1 MiB from the
-   `UnixStream` with a short timeout to avoid indefinite blocking if the client
-   fails to close the connection. It deserialises the received JSON into a
-   `CommentRequest` and uses the sender half of the `yaque` channel to enqueue
-   the request. After enqueuing, the task terminates.
+5. **Handle Client:** This per-client task reads at most 1 MiB within
+   `CLIENT_READ_TIMEOUT_SECS` (default: 5 s); larger or slower requests are
+   rejected with a timeout or size error. It deserialises the received JSON
+   into a `CommentRequest` and uses the sender half of the `yaque` channel to
+   enqueue the request. After enqueuing, the task terminates.
 
 This design makes the request ingestion process highly concurrent and robust,
 capable of handling multiple simultaneous client connections without impacting

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -488,13 +488,13 @@ Its workflow is as follows:
    accepting a new connection, it immediately spawns a new, short-lived `tokio`
    task to handle that specific client.
 
-5. **Handle Client:** This per-client task reads at most
-   `MAX_REQUEST_BYTES` (1 MiB by default) within `CLIENT_READ_TIMEOUT_SECS`
-   (default: 5 s). Both limits are compile-time constants and can be adjusted.
-   Larger or slower requests are rejected with a timeout or size error. It
-   deserialises the received JSON into a `CommentRequest` and uses the sender
-   half of the `yaque` channel to enqueue the request. After enqueuing, the
-   task terminates.
+5. **Handle Client:** This per-client task reads at most 1 MiB within
+   `CLIENT_READ_TIMEOUT_SECS` (default: 5 s); larger or slower requests are
+   rejected with a timeout or size error. The `MAX_REQUEST_BYTES` and
+   `CLIENT_READ_TIMEOUT_SECS` limits are compile-time constants that can be
+   adjusted. It deserialises the received JSON into a `CommentRequest` and uses
+   the sender half of the `yaque` channel to enqueue the request. After
+   enqueuing, the task terminates.
 
 This design makes the request ingestion process highly concurrent and robust,
 capable of handling multiple simultaneous client connections without impacting

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -488,10 +488,11 @@ Its workflow is as follows:
    accepting a new connection, it immediately spawns a new, short-lived `tokio`
    task to handle that specific client.
 
-5. **Handle Client:** This per-client task will read all data from the
-   `UnixStream`, deserialize the received JSON into a `CommentRequest` struct,
-   and then use the sender half of the `yaque` channel to enqueue the request.
-   After enqueuing, the task terminates.
+5. **Handle Client:** This per-client task reads up to 1 MiB from the
+   `UnixStream` with a short timeout to avoid indefinite blocking if the client
+   fails to close the connection. It deserialises the received JSON into a
+   `CommentRequest` and uses the sender half of the `yaque` channel to enqueue
+   the request. After enqueuing, the task terminates.
 
 This design makes the request ingestion process highly concurrent and robust,
 capable of handling multiple simultaneous client connections without impacting

--- a/docs/comenq-design.md
+++ b/docs/comenq-design.md
@@ -488,11 +488,13 @@ Its workflow is as follows:
    accepting a new connection, it immediately spawns a new, short-lived `tokio`
    task to handle that specific client.
 
-5. **Handle Client:** This per-client task reads at most 1 MiB within
-   `CLIENT_READ_TIMEOUT_SECS` (default: 5 s); larger or slower requests are
-   rejected with a timeout or size error. It deserialises the received JSON
-   into a `CommentRequest` and uses the sender half of the `yaque` channel to
-   enqueue the request. After enqueuing, the task terminates.
+5. **Handle Client:** This per-client task reads at most
+   `MAX_REQUEST_BYTES` (1 MiB by default) within `CLIENT_READ_TIMEOUT_SECS`
+   (default: 5 s). Both limits are compile-time constants and can be adjusted.
+   Larger or slower requests are rejected with a timeout or size error. It
+   deserialises the received JSON into a `CommentRequest` and uses the sender
+   half of the `yaque` channel to enqueue the request. After enqueuing, the
+   task terminates.
 
 This design makes the request ingestion process highly concurrent and robust,
 capable of handling multiple simultaneous client connections without impacting


### PR DESCRIPTION
## Summary
- test listener times out when client fails to close connection
- document read timeout in design doc

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

closes #8

------
https://chatgpt.com/codex/tasks/task_e_68c3f823c7bc8322b95cda8fb353bdd0

## Summary by Sourcery

Document client read timeout behavior and add a test for idle client connections timing out

Documentation:
- Add description of 1 MiB read limit with timeout to the design documentation

Tests:
- Introduce a test to verify handle_client errors out when the client fails to close the connection