### PR TITLE
Refactor queue metadata filtering

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -16,7 +16,11 @@ pub use crate::supervisor::run;
 /// Run the worker that drains the queue and talks to the GitHub API.
 pub use crate::worker::run_worker;
 /// Control handle and lifecycle hooks for the worker task.
-pub use crate::worker::{WorkerControl, WorkerHooks, is_metadata_file};
+pub use crate::worker::{WorkerControl, WorkerHooks};
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub use crate::util::is_metadata_file;
 
 /// Listener utilities for accepting client connections.
 ///

--- a/crates/comenqd/src/lib.rs
+++ b/crates/comenqd/src/lib.rs
@@ -19,6 +19,7 @@ pub mod config;
 
 mod listener;
 mod supervisor;
+mod util;
 mod worker;
 
 pub mod daemon;

--- a/crates/comenqd/src/util.rs
+++ b/crates/comenqd/src/util.rs
@@ -1,0 +1,25 @@
+//! Internal utilities shared by daemon components.
+//!
+//! Provides helpers used across production code and tests.
+
+use std::ffi::OsStr;
+
+/// Names of files storing queue metadata.
+///
+/// Extend this list when new metadata files are introduced.
+pub(crate) const METADATA_FILE_NAMES: [&str; 2] = ["version", "recv.lock"];
+
+/// Returns whether a file name represents queue metadata.
+///
+/// # Examples
+///
+/// ```
+/// use comenqd::daemon::is_metadata_file;
+/// use std::ffi::OsStr;
+/// assert!(is_metadata_file(OsStr::new("version")));
+/// assert!(!is_metadata_file(OsStr::new("0001")));
+/// ```
+pub fn is_metadata_file(name: impl AsRef<OsStr>) -> bool {
+    let name = name.as_ref();
+    METADATA_FILE_NAMES.iter().any(|m| OsStr::new(m) == name)
+}

--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -334,11 +334,7 @@ mod worker_tests {
         let data_files = stdfs::read_dir(&ctx.cfg.queue_path)
             .expect("read queue directory")
             .filter_map(Result::ok)
-            .filter(|e| {
-                let name = e.file_name();
-                let name = name.to_string_lossy();
-                !is_metadata_file(&name)
-            })
+            .filter(|e| !is_metadata_file(e.file_name()))
             .count();
         assert_eq!(
             data_files, 0,

--- a/tests/steps/worker_steps.rs
+++ b/tests/steps/worker_steps.rs
@@ -187,11 +187,7 @@ async fn queue_retains(world: &mut WorkerWorld) {
     let job_count = std::fs::read_dir(&cfg.queue_path)
         .expect("queue directory should be readable")
         .filter_map(Result::ok)
-        .filter(|e| {
-            let name = e.file_name();
-            let name = name.to_string_lossy();
-            !is_metadata_file(&name)
-        })
+        .filter(|e| !is_metadata_file(e.file_name()))
         .count();
     assert!(job_count > 0, "queue should retain at least one job file");
     world.shutdown_and_join().await;


### PR DESCRIPTION
## Summary
- extract metadata file detection into is_metadata_file helper
- use shared helper in worker and tests

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #67

------
https://chatgpt.com/codex/tasks/task_e_68c3f8d417248322a134e1b5f0dfad57

## Summary by Sourcery

Refactor queue metadata detection into a shared helper and update worker code and tests to use it

Enhancements:
- Add `is_metadata_file` helper for identifying queue metadata files
- Export `is_metadata_file` in the daemon interface
- Replace inline metadata checks in worker implementation and tests with the shared helper and remove duplicated logic