### PR TITLE
Fix incorrect Notified await and remove stray lint expectation

### DIFF
--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -24,9 +24,9 @@ pub use crate::util::is_metadata_file;
 
 /// Listener utilities for accepting client connections.
 ///
-/// Re-exports functions from the internal `listener` module so integration tests
-/// can exercise socket preparation and client handling without exposing the
-/// entire module as part of the public API.
+/// Re-exports selected listener APIs (functions and constants) so integration
+/// tests can exercise socket preparation, client handling, and read limits
+/// without exposing the entire `listener` module publicly.
 pub mod listener {
     pub use crate::listener::{
         CLIENT_READ_TIMEOUT_SECS, MAX_REQUEST_BYTES, handle_client, prepare_listener, run_listener,

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -28,5 +28,7 @@ pub use crate::util::is_metadata_file;
 /// can exercise socket preparation and client handling without exposing the
 /// entire module as part of the public API.
 pub mod listener {
-    pub use crate::listener::{handle_client, prepare_listener, run_listener};
+    pub use crate::listener::{
+        CLIENT_READ_TIMEOUT_SECS, MAX_REQUEST_BYTES, handle_client, prepare_listener, run_listener,
+    };
 }

--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -283,7 +283,7 @@ mod worker_tests {
         let ctx = ctx.await;
         let server = Arc::new(ctx.server);
         let drained = Arc::new(Notify::new());
-        let mut drained_notified = drained.notified();
+        let drained_notified = drained.notified();
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let control = WorkerControl {
             shutdown: shutdown_rx,
@@ -299,7 +299,7 @@ mod worker_tests {
             DRAINED_NOTIFICATION,
             "worker drained notification",
             || async {
-                (&mut drained_notified).await;
+                drained_notified.await;
                 Ok(())
             },
         )
@@ -354,7 +354,7 @@ mod worker_tests {
         let server = Arc::new(ctx.server);
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let enqueued = Arc::new(Notify::new());
-        let mut enqueued_notified = enqueued.notified();
+        let enqueued_notified = enqueued.notified();
         let control = WorkerControl {
             shutdown: shutdown_rx,
             hooks: WorkerHooks {
@@ -366,7 +366,7 @@ mod worker_tests {
         let h = tokio::spawn(run_worker(ctx.cfg.clone(), ctx.rx, ctx.octo, control));
 
         timeout_with_retries(WORKER_SUCCESS, "worker enqueued", || async {
-            (&mut enqueued_notified).await;
+            enqueued_notified.await;
             Ok(())
         })
         .await

--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -283,27 +283,26 @@ mod worker_tests {
         let ctx = ctx.await;
         let server = Arc::new(ctx.server);
         let drained = Arc::new(Notify::new());
-        let drained_notified = drained.notified();
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let control = WorkerControl {
             shutdown: shutdown_rx,
             hooks: WorkerHooks {
                 enqueued: None,
                 idle: None,
-                drained: Some(drained),
+                drained: Some(drained.clone()),
             },
         };
         let h = tokio::spawn(run_worker(ctx.cfg.clone(), ctx.rx, ctx.octo, control));
 
-        if let Err(e) = timeout_with_retries(
-            DRAINED_NOTIFICATION,
-            "worker drained notification",
-            || async {
-                drained_notified.await;
-                Ok(())
-            },
-        )
-        .await
+        if let Err(e) =
+            timeout_with_retries(DRAINED_NOTIFICATION, "worker drained notification", || {
+                let drained = drained.clone();
+                async move {
+                    drained.notified().await;
+                    Ok(())
+                }
+            })
+            .await
         {
             let diagnostics = diagnose_queue_state(&ctx.cfg, &server, 0).await;
             tracing::error!("Timeout waiting for worker drained notification: {e}");
@@ -354,20 +353,22 @@ mod worker_tests {
         let server = Arc::new(ctx.server);
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let enqueued = Arc::new(Notify::new());
-        let enqueued_notified = enqueued.notified();
         let control = WorkerControl {
             shutdown: shutdown_rx,
             hooks: WorkerHooks {
-                enqueued: Some(enqueued),
+                enqueued: Some(enqueued.clone()),
                 idle: None,
                 drained: None,
             },
         };
         let h = tokio::spawn(run_worker(ctx.cfg.clone(), ctx.rx, ctx.octo, control));
 
-        timeout_with_retries(WORKER_SUCCESS, "worker enqueued", || async {
-            enqueued_notified.await;
-            Ok(())
+        timeout_with_retries(WORKER_SUCCESS, "worker enqueued", || {
+            let enqueued = enqueued.clone();
+            async move {
+                enqueued.notified().await;
+                Ok(())
+            }
         })
         .await
         .expect("worker picked up job");

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -13,7 +13,6 @@ pub const PROGRESSIVE_RETRY_PERCENTS: [u64; 3] = [50, 100, 150];
 
 #[derive(Debug, Clone, Copy)]
 pub enum TestComplexity {
-    #[expect(dead_code, reason = "Constructed in integration tests but unused here")]
     Simple,
     Moderate,
     Complex,

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -91,6 +91,13 @@ where
     Err(format!("{operation_name} exhausted all retry attempts"))
 }
 
+#[test]
+fn uses_all_test_complexity_variants() {
+    let _ = TimeoutConfig::new(1, TestComplexity::Simple);
+    let _ = TimeoutConfig::new(1, TestComplexity::Moderate);
+    let _ = TimeoutConfig::new(1, TestComplexity::Complex);
+}
+
 /// Map a task [`JoinError`] into a concise diagnostic message.
 ///
 /// ```ignore

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -91,11 +91,12 @@ where
     Err(format!("{operation_name} exhausted all retry attempts"))
 }
 
-#[test]
-fn uses_all_test_complexity_variants() {
-    let _ = TimeoutConfig::new(1, TestComplexity::Simple);
-    let _ = TimeoutConfig::new(1, TestComplexity::Moderate);
-    let _ = TimeoutConfig::new(1, TestComplexity::Complex);
+#[rstest]
+#[case(TestComplexity::Simple)]
+#[case(TestComplexity::Moderate)]
+#[case(TestComplexity::Complex)]
+fn uses_all_test_complexity_variants(#[case] complexity: TestComplexity) {
+    let _ = TimeoutConfig::new(1, complexity);
 }
 
 /// Map a task [`JoinError`] into a concise diagnostic message.

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -11,14 +11,14 @@ pub const COVERAGE_MULTIPLIER: u64 = 5;
 pub const CI_MULTIPLIER: u64 = 2;
 pub const PROGRESSIVE_RETRY_PERCENTS: [u64; 3] = [50, 100, 150];
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum TestComplexity {
     Simple,
     Moderate,
     Complex,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TimeoutConfig {
     base_seconds: u64,
     complexity: TestComplexity,
@@ -96,7 +96,7 @@ where
 #[case(TestComplexity::Moderate)]
 #[case(TestComplexity::Complex)]
 fn uses_all_test_complexity_variants(#[case] complexity: TestComplexity) {
-    let _ = TimeoutConfig::new(1, complexity);
+    drop(TimeoutConfig::new(1, complexity));
 }
 
 /// Map a task [`JoinError`] into a concise diagnostic message.
@@ -117,7 +117,7 @@ pub(crate) fn join_err(name: &str, e: JoinError) -> String {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum JoinScenario {
     Cancelled,
     Panicked,


### PR DESCRIPTION
## Summary
- remove unused lint expectation from `TestComplexity`
- await `Notified` instances without borrowing to satisfy `Unpin`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ae2b6a308322a72309ae796d7507

## Summary by Sourcery

Remove unused dead_code lint expectation and streamline Notify::notified() usage in tests by awaiting the returned futures directly rather than through mutable references

Bug Fixes:
- Remove incorrect mutable borrows when awaiting Notify::notified() futures to satisfy Unpin requirements
- Eliminate stray unused lint expectation on the TestComplexity enum

Enhancements:
- Simplify test code by awaiting Notify::notified() directly without `&mut`

Tests:
- Update daemon and worker integration tests to capture and await `Notify::notified()` futures directly