### PR TITLE
Remove redundant token clone in config step

### DIFF
--- a/tests/steps/config_steps.rs
+++ b/tests/steps/config_steps.rs
@@ -71,16 +71,8 @@ fn config_without_socket(world: &mut ConfigWorld, token: String) {
 }
 
 #[given(regex = r#"^a configuration file with token \"(.+)\" and no cooldown_period_seconds$"#)]
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "cucumber requires owned values"
-)]
-#[expect(
-    clippy::redundant_clone,
-    reason = "cucumber framework passes tokens by value"
-)]
 fn config_without_cooldown(world: &mut ConfigWorld, token: String) {
-    config_file_with_token(world, token.clone());
+    config_file_with_token(world, token);
 }
 
 #[given("a missing configuration file")]


### PR DESCRIPTION
## Summary
- clean up config_without_cooldown test step by moving token instead of cloning
- drop obsolete lint expectations

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c74d4e59888322a11c483c739a6966

## Summary by Sourcery

Simplify the config_without_cooldown test step by moving the token instead of cloning it and removing obsolete lint expectations.

Enhancements:
- Pass token by value to config_file_with_token instead of cloning it.

Tests:
- Remove outdated Clippy expect annotations for needless_pass_by_value and redundant_clone lints.