### PR TITLE
Add regression tests for malformed workflow YAML

### DIFF
--- a/test-support/src/workflow.rs
+++ b/test-support/src/workflow.rs
@@ -83,4 +83,43 @@ mod tests {
         ";
         assert!(!uses_shared_release_actions(yaml).expect("parse"));
     }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "simplify test output")]
+    fn malformed_yaml_errors() {
+        let yaml = "jobs: [";
+        assert!(uses_shared_release_actions(yaml).is_err());
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "simplify test output")]
+    fn missing_jobs_returns_false() {
+        let yaml = r"
+        name: release
+        ";
+        assert!(!uses_shared_release_actions(yaml).expect("parse"));
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "simplify test output")]
+    fn missing_steps_returns_false() {
+        let yaml = r"
+        jobs:
+          release:
+            name: publish
+        ";
+        assert!(!uses_shared_release_actions(yaml).expect("parse"));
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "simplify test output")]
+    fn non_sequence_steps_returns_false() {
+        let yaml = r"
+        jobs:
+          release:
+            steps:
+              uses: leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
+        ";
+        assert!(!uses_shared_release_actions(yaml).expect("parse"));
+    }
 }

--- a/test-support/src/workflow.rs
+++ b/test-support/src/workflow.rs
@@ -88,7 +88,7 @@ mod tests {
     #[expect(clippy::expect_used, reason = "simplify test output")]
     fn malformed_yaml_errors() {
         let yaml = "jobs: [";
-        assert!(uses_shared_release_actions(yaml).is_err());
+        _ = uses_shared_release_actions(yaml).expect_err("expected parse failure");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add unit coverage for malformed release workflow YAML and missing job definitions
- ensure missing steps or non-sequence steps return `false`

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d9bd821478832287690a17febdb58e

## Summary by Sourcery

Tests:
- Add tests verifying error on malformed workflow YAML and false returns for missing jobs, missing steps, and non-sequence steps