### PR TITLE
Coverage test failure

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,11 @@
+# .config/nextest.toml
+[profile.default]
+# Kill any test once it crosses 60s.
+slow-timeout = { period = "60s", terminate-after = 1, grace-period = "5s" }
+
+# Put a hard ceiling on the whole run.
+global-timeout = "10m"
+
+# Exclude cucumber BDD tests (they don't support nextest's --list command).
+# Run cucumber tests separately with `cargo test`.
+default-filter = "not binary(cucumber)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+      - name: Install nextest
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: nextest@0.9.108
       - name: Format
         run: make check-fmt
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
         with:
-          tool: nextest@0.9.108
+          tool: nextest@0.9.114
       - name: Format
         run: make check-fmt
       - name: Lint

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -12,7 +12,6 @@
   },
   "ignores": [
     "**/.venv/**",
-    ".node_modules/**",
     "**/node_modules/**",
     "**/target/**",
     ".terraform/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,11 +1,22 @@
 {
   "config": {
+    "MD004": { "style": "dash" },
+    "MD010": { "code_blocks": false },
     "MD013": {
       "line_length": 80,
       "code_block_line_length": 120,
-      "tables": false
+      "tables": false,
+      "headings": false
     },
-    "MD029": { "style": "ordered" },
-    "MD040": { "code_blocks": true }
-  }
+    "MD029": { "style": "ordered" }
+  },
+  "ignores": [
+    "**/.venv/**",
+    ".node_modules/**",
+    "**/node_modules/**",
+    "**/target/**",
+    ".terraform/**",
+    ".uv-cache/**",
+    "CRUSH.md"
+  ]
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,8 +14,8 @@
     "**/.venv/**",
     "**/node_modules/**",
     "**/target/**",
-    ".terraform/**",
-    ".uv-cache/**",
+    "**/.terraform/**",
+    "**/.uv-cache/**",
     "CRUSH.md"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
  "wiremock",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ markdownlint: ## Lint Markdown files
 	$(MDLINT) "**/*.md"
 
 nixie: ## Validate Mermaid diagrams
-	$(NIXIE) --no-sandbox
+	$(NIXIE) --no-sandbox "**/*.md"
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ APP ?= comenq
 CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --workspace --all-targets --all-features -- -D warnings
-MDLINT ?= markdownlint
+MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 COV_MIN ?= 0 # Minimum line coverage percentage for coverage targets
 
@@ -62,10 +62,10 @@ check-fmt: ## Verify formatting
 	$(CARGO) fmt --all -- --check
 
 markdownlint: ## Lint Markdown files
-	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
+	$(MDLINT) "**/*.md"
 
 nixie: ## Validate Mermaid diagrams
-	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
+	$(NIXIE) --no-sandbox
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/crates/comenqd/src/listener.rs
+++ b/crates/comenqd/src/listener.rs
@@ -28,7 +28,7 @@ use crate::supervisor::backoff;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use comenqd::listener::prepare_listener;
+/// use comenqd::daemon::listener::prepare_listener;
 /// use tempfile::tempdir;
 /// let dir = tempdir().expect("create tempdir");
 /// let sock = dir.path().join("sock");

--- a/crates/comenqd/src/listener.rs
+++ b/crates/comenqd/src/listener.rs
@@ -169,8 +169,8 @@ mod tests {
     use std::thread;
     use tempfile::tempdir;
 
-    #[test]
-    fn prepare_listener_prevents_pre_bind_race() {
+    #[tokio::test]
+    async fn prepare_listener_prevents_pre_bind_race() {
         let dir = tempdir().expect("create tempdir");
         let sock = dir.path().join("sock");
         let stop = Arc::new(AtomicBool::new(false));

--- a/crates/comenqd/src/logging.rs
+++ b/crates/comenqd/src/logging.rs
@@ -57,7 +57,10 @@ where
 ///
 /// init_with_writer_and_filter(fmt::writer::BoxMakeWriter::new(std::io::stdout), "info");
 /// ```
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "used only in tests to avoid environment mutation")
+)]
 pub fn init_with_writer_and_filter<W>(writer: W, filter: &str)
 where
     W: for<'a> MakeWriter<'a> + Send + Sync + 'static,

--- a/crates/comenqd/src/logging.rs
+++ b/crates/comenqd/src/logging.rs
@@ -44,7 +44,7 @@ where
         .init();
 }
 
-/// Initialize logging with a custom writer and explicit filter.
+/// Initialise logging with a custom writer and explicit filter.
 ///
 /// This avoids reading from the environment, making it suitable for tests
 /// where environment mutation is forbidden.
@@ -57,9 +57,13 @@ where
 ///
 /// init_with_writer_and_filter(fmt::writer::BoxMakeWriter::new(std::io::stdout), "info");
 /// ```
+#[cfg(feature = "test-support")]
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "used only in tests to avoid environment mutation")
+    expect(
+        dead_code,
+        reason = "feature-gated test helper; used only when #[cfg(test)] is also set"
+    )
 )]
 pub fn init_with_writer_and_filter<W>(writer: W, filter: &str)
 where
@@ -71,7 +75,7 @@ where
         .init();
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};

--- a/crates/comenqd/src/logging.rs
+++ b/crates/comenqd/src/logging.rs
@@ -44,42 +44,12 @@ where
         .init();
 }
 
-/// Initialise logging with a custom writer and explicit filter.
-///
-/// This avoids reading from the environment, making it suitable for tests
-/// where environment mutation is forbidden.
-///
-/// # Examples
-///
-/// ```rust,no_run
-/// use comenqd::logging::init_with_writer_and_filter;
-/// use tracing_subscriber::fmt;
-///
-/// init_with_writer_and_filter(fmt::writer::BoxMakeWriter::new(std::io::stdout), "info");
-/// ```
-#[cfg(feature = "test-support")]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "feature-gated test helper; used only when #[cfg(test)] is also set"
-    )
-)]
-pub fn init_with_writer_and_filter<W>(writer: W, filter: &str)
-where
-    W: for<'a> MakeWriter<'a> + Send + Sync + 'static,
-{
-    fmt()
-        .with_env_filter(EnvFilter::new(filter))
-        .with_writer(writer)
-        .init();
-}
-
-#[cfg(all(test, feature = "test-support"))]
+#[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::{Arc, Mutex};
+    use test_support::logging::init_with_writer_and_filter;
     use tracing::info;
+    use tracing_subscriber::fmt::MakeWriter;
 
     #[derive(Clone)]
     struct BufMakeWriter {

--- a/crates/comenqd/src/logging.rs
+++ b/crates/comenqd/src/logging.rs
@@ -1,13 +1,13 @@
 //! Logging utilities for the daemon.
 //!
-//! Initializes structured logging using `tracing` and
+//! Initialises structured logging using `tracing` and
 //! `tracing-subscriber`, reading filter settings from the `RUST_LOG`
 //! environment variable.
 
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::{EnvFilter, fmt};
 
-/// Initialize the global tracing subscriber.
+/// Initialise the global tracing subscriber.
 ///
 /// Call `init` before any logging statements to avoid missing logs.
 ///
@@ -16,15 +16,15 @@ use tracing_subscriber::{EnvFilter, fmt};
 /// ```rust,no_run
 /// use comenqd::logging::init;
 ///
-/// // Initialize logging as early as possible.
+/// // Initialise logging as early as possible.
 /// init();
-/// tracing::info!("Logging is initialized!");
+/// tracing::info!("Logging is initialised!");
 /// ```
 pub fn init() {
     init_with_writer(fmt::writer::BoxMakeWriter::new(std::io::stdout));
 }
 
-/// Initialize logging with a custom writer.
+/// Initialise logging with a custom writer.
 ///
 /// # Examples
 ///

--- a/crates/comenqd/src/logging.rs
+++ b/crates/comenqd/src/logging.rs
@@ -14,13 +14,11 @@ use tracing_subscriber::{EnvFilter, fmt};
 /// # Examples
 ///
 /// ```rust,no_run
-/// use crate::logging::init;
+/// use comenqd::logging::init;
 ///
-/// fn main() {
-///     // Initialize logging as early as possible.
-///     init();
-///     tracing::info!("Logging is initialized!");
-/// }
+/// // Initialize logging as early as possible.
+/// init();
+/// tracing::info!("Logging is initialized!");
 /// ```
 pub fn init() {
     init_with_writer(fmt::writer::BoxMakeWriter::new(std::io::stdout));
@@ -31,12 +29,10 @@ pub fn init() {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use crate::logging::init_with_writer;
+/// use comenqd::logging::init_with_writer;
 /// use tracing_subscriber::fmt;
 ///
-/// fn main() {
-///     init_with_writer(fmt::writer::BoxMakeWriter::new(std::io::stdout));
-/// }
+/// init_with_writer(fmt::writer::BoxMakeWriter::new(std::io::stdout));
 /// ```
 pub fn init_with_writer<W>(writer: W)
 where

--- a/crates/comenqd/src/supervisor/tests.rs
+++ b/crates/comenqd/src/supervisor/tests.rs
@@ -28,7 +28,10 @@ fn create_cancelled_join_error() -> JoinError {
     tokio::runtime::Runtime::new()
         .expect("create runtime")
         .block_on(async {
-            let handle = tokio::spawn(async {});
+            // Use yield_now to ensure task doesn't complete before abort() is called
+            let handle = tokio::spawn(async {
+                tokio::task::yield_now().await;
+            });
             handle.abort();
             handle.await.unwrap_err()
         })

--- a/crates/comenqd/src/util.rs
+++ b/crates/comenqd/src/util.rs
@@ -23,3 +23,37 @@ pub fn is_metadata_file(name: impl AsRef<OsStr>) -> bool {
     let name = name.as_ref();
     METADATA_FILE_NAMES.iter().any(|m| OsStr::new(m) == name)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_metadata_file_recognises_version() {
+        assert!(is_metadata_file("version"));
+    }
+
+    #[test]
+    fn is_metadata_file_recognises_recv_lock() {
+        assert!(is_metadata_file("recv.lock"));
+    }
+
+    #[test]
+    fn is_metadata_file_recognises_send_lock() {
+        assert!(is_metadata_file("send.lock"));
+    }
+
+    #[test]
+    fn is_metadata_file_rejects_queue_segments() {
+        assert!(!is_metadata_file("0000"));
+        assert!(!is_metadata_file("0001"));
+        assert!(!is_metadata_file("9999"));
+    }
+
+    #[test]
+    fn is_metadata_file_rejects_arbitrary_names() {
+        assert!(!is_metadata_file("data.json"));
+        assert!(!is_metadata_file("lock"));
+        assert!(!is_metadata_file(""));
+    }
+}

--- a/crates/comenqd/src/util.rs
+++ b/crates/comenqd/src/util.rs
@@ -7,7 +7,7 @@ use std::ffi::OsStr;
 /// Names of files storing queue metadata.
 ///
 /// Extend this list when new metadata files are introduced.
-pub(crate) const METADATA_FILE_NAMES: [&str; 2] = ["version", "recv.lock"];
+pub(crate) const METADATA_FILE_NAMES: [&str; 3] = ["version", "recv.lock", "send.lock"];
 
 /// Returns whether a file name represents queue metadata.
 ///

--- a/crates/comenqd/src/util.rs
+++ b/crates/comenqd/src/util.rs
@@ -27,33 +27,24 @@ pub fn is_metadata_file(name: impl AsRef<OsStr>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn is_metadata_file_recognises_version() {
-        assert!(is_metadata_file("version"));
+    #[rstest]
+    #[case::version("version")]
+    #[case::recv_lock("recv.lock")]
+    #[case::send_lock("send.lock")]
+    fn is_metadata_file_recognises_metadata(#[case] name: &str) {
+        assert!(is_metadata_file(name));
     }
 
-    #[test]
-    fn is_metadata_file_recognises_recv_lock() {
-        assert!(is_metadata_file("recv.lock"));
-    }
-
-    #[test]
-    fn is_metadata_file_recognises_send_lock() {
-        assert!(is_metadata_file("send.lock"));
-    }
-
-    #[test]
-    fn is_metadata_file_rejects_queue_segments() {
-        assert!(!is_metadata_file("0000"));
-        assert!(!is_metadata_file("0001"));
-        assert!(!is_metadata_file("9999"));
-    }
-
-    #[test]
-    fn is_metadata_file_rejects_arbitrary_names() {
-        assert!(!is_metadata_file("data.json"));
-        assert!(!is_metadata_file("lock"));
-        assert!(!is_metadata_file(""));
+    #[rstest]
+    #[case::segment_0000("0000")]
+    #[case::segment_0001("0001")]
+    #[case::segment_9999("9999")]
+    #[case::data_json("data.json")]
+    #[case::lock("lock")]
+    #[case::empty("")]
+    fn is_metadata_file_rejects_non_metadata(#[case] name: &str) {
+        assert!(!is_metadata_file(name));
     }
 }

--- a/crates/comenqd/src/worker.rs
+++ b/crates/comenqd/src/worker.rs
@@ -260,7 +260,7 @@ mod tests {
         let result = WorkerHooks::wait_or_shutdown(0, &mut rx).await;
         assert!(!result, "should return false when timeout expires");
         assert!(
-            start.elapsed().as_millis() < 100,
+            start.elapsed().as_millis() < 500,
             "zero-second wait should return immediately"
         );
     }

--- a/crates/comenqd/src/worker.rs
+++ b/crates/comenqd/src/worker.rs
@@ -62,7 +62,7 @@ pub struct WorkerHooks {
     /// Signalled when the queue is empty and the worker is idle.
     #[cfg_attr(
         not(any(test, feature = "test-support")),
-        allow(dead_code, reason = "test hook")
+        expect(dead_code, reason = "test hook only used in test/test-support builds")
     )]
     pub drained: Option<Arc<Notify>>,
 }

--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -255,7 +255,7 @@ mod worker_tests {
         Mock::given(method("POST"))
             .and(path("/repos/o/r/issues/1/comments"))
             .respond_with(ResponseTemplate::new(status).set_body_json(response_body))
-            .expect(1..)  // Expect at least one request
+            .expect(1..) // Expect at least one request
             .mount(&server)
             .await;
         let octo = octocrab_for(&server);

--- a/crates/comenqd/tests/fixtures/github_comment_response.json
+++ b/crates/comenqd/tests/fixtures/github_comment_response.json
@@ -1,0 +1,30 @@
+{
+    "id": 1,
+    "node_id": "IC_test",
+    "url": "https://api.github.com/repos/o/r/issues/comments/1",
+    "html_url": "https://github.com/o/r/issues/1#issuecomment-1",
+    "body": "b",
+    "user": {
+        "login": "test-user",
+        "id": 1,
+        "node_id": "U_test",
+        "avatar_url": "https://example.com/avatar",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/test-user",
+        "html_url": "https://github.com/test-user",
+        "followers_url": "https://api.github.com/users/test-user/followers",
+        "following_url": "https://api.github.com/users/test-user/following{/other_user}",
+        "gists_url": "https://api.github.com/users/test-user/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/test-user/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/test-user/subscriptions",
+        "organizations_url": "https://api.github.com/users/test-user/orgs",
+        "repos_url": "https://api.github.com/users/test-user/repos",
+        "events_url": "https://api.github.com/users/test-user/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/test-user/received_events",
+        "type": "User",
+        "site_admin": false
+    },
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z",
+    "author_association": "NONE"
+}

--- a/crates/comenqd/tests/fixtures/github_error_response.json
+++ b/crates/comenqd/tests/fixtures/github_error_response.json
@@ -1,0 +1,4 @@
+{
+    "message": "Internal Server Error",
+    "documentation_url": "https://docs.github.com/rest"
+}

--- a/crates/comenqd/tests/supervisor.rs
+++ b/crates/comenqd/tests/supervisor.rs
@@ -67,7 +67,7 @@ async fn supervise_until_restarts<F1, F2>(
     {
         t1.abort();
         t2.abort();
-        panic!("Supervisor timeout after {:?}", timeout_duration);
+        panic!("Supervisor timeout after {timeout_duration:?}");
     }
 }
 
@@ -86,7 +86,7 @@ async fn restarts_failed_task(#[case] failing: FailingTask) {
     let attempts_clone = Arc::clone(&attempts);
 
     type Maker = Box<dyn FnMut() -> JoinHandle<anyhow::Result<()>> + Send>;
-    let (mut listener_maker, mut worker_maker): (Maker, Maker) = match failing {
+    let (listener_maker, worker_maker): (Maker, Maker) = match failing {
         FailingTask::Listener => {
             let listener_maker: Maker = Box::new({
                 let attempts = Arc::clone(&attempts_clone);
@@ -148,8 +148,8 @@ async fn restarts_failed_task(#[case] failing: FailingTask) {
     };
 
     let supervisor = tokio::spawn(supervise_until_restarts(
-        move || listener_maker(),
-        move || worker_maker(),
+        listener_maker,
+        worker_maker,
         shutdown_rx,
     ));
     while attempts.load(Ordering::Relaxed) < 2 {

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -40,7 +40,6 @@ impl TimeoutConfig {
 
     /// Set explicit CI flag, avoiding environment reads.
     #[must_use]
-    #[allow(dead_code)] // Used in retry_helper.rs, not daemon.rs
     pub const fn with_ci(mut self, ci: bool) -> Self {
         self.ci = Some(ci);
         self
@@ -48,7 +47,6 @@ impl TimeoutConfig {
 
     /// Set explicit coverage flag, avoiding environment reads.
     #[must_use]
-    #[allow(dead_code)] // Used in retry_helper.rs, not daemon.rs
     pub const fn with_coverage(mut self, coverage: bool) -> Self {
         self.coverage = Some(coverage);
         self

--- a/crates/comenqd/tests/util.rs
+++ b/crates/comenqd/tests/util.rs
@@ -96,7 +96,7 @@ where
 #[case(TestComplexity::Moderate)]
 #[case(TestComplexity::Complex)]
 fn uses_all_test_complexity_variants(#[case] complexity: TestComplexity) {
-    drop(TimeoutConfig::new(1, complexity));
+    let _ = TimeoutConfig::new(1, complexity);
 }
 
 /// Map a task [`JoinError`] into a concise diagnostic message.

--- a/test-support/Cargo.toml
+++ b/test-support/Cargo.toml
@@ -10,6 +10,7 @@ tempfile = { workspace = true }
 wiremock = "^0.6"
 serde_yaml = { workspace = true }
 serde = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 serial_test = "^2"

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod daemon;
 pub mod env_guard;
+pub mod logging;
 pub mod util;
 mod workflow;
 pub use workflow::uses_shared_release_actions;

--- a/test-support/src/logging.rs
+++ b/test-support/src/logging.rs
@@ -1,0 +1,30 @@
+//! Logging utilities for tests.
+//!
+//! Provides test-safe logging initialisation that avoids reading from the
+//! environment.
+
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::{EnvFilter, fmt};
+
+/// Initialise logging with a custom writer and explicit filter.
+///
+/// This avoids reading from the environment, making it suitable for tests
+/// where environment mutation is forbidden.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use test_support::logging::init_with_writer_and_filter;
+/// use tracing_subscriber::fmt;
+///
+/// init_with_writer_and_filter(fmt::writer::BoxMakeWriter::new(std::io::stdout), "info");
+/// ```
+pub fn init_with_writer_and_filter<W>(writer: W, filter: &str)
+where
+    W: for<'a> MakeWriter<'a> + Send + Sync + 'static,
+{
+    fmt()
+        .with_env_filter(EnvFilter::new(filter))
+        .with_writer(writer)
+        .init();
+}

--- a/test-support/src/workflow.rs
+++ b/test-support/src/workflow.rs
@@ -83,10 +83,9 @@ mod tests {
         jobs:
           release:
             steps:
-              - uses: {}
+              - uses: {EXPECTED_RUST_BUILDER}
               - uses: softprops/action-gh-release@v2
-        "#,
-            EXPECTED_RUST_BUILDER,
+        "#
         );
         assert!(uses_shared_release_actions(&yaml).expect("parse"));
     }
@@ -111,9 +110,8 @@ mod tests {
         jobs:
           release:
             steps:
-              - uses: {}
-        "#,
-            EXPECTED_RUST_BUILDER,
+              - uses: {EXPECTED_RUST_BUILDER}
+        "#
         );
         assert!(!uses_shared_release_actions(&yaml).expect("parse"));
     }


### PR DESCRIPTION
## Summary by Sourcery

Improve worker shutdown semantics and test reliability while integrating nextest-based coverage into the build.

New Features:
- Add configurable test-support feature gating for worker drained hooks to allow use outside unit tests.
- Introduce a nextest configuration file to control per-test and global timeouts and exclude cucumber binaries from default runs.

Bug Fixes:
- Correct worker queue metadata detection to ignore send.lock files when checking for emptiness.
- Fix supervisor restart test by removing unnecessary mutable closures that could interfere with task construction.
- Adjust listener race-condition test to be async-compatible using tokio.

Enhancements:
- Refine worker hook notifications to use single-waiter semantics and idle-based signalling, and make shutdown-aware cooldown waits break out of the worker loop.
- Improve worker request handling tests with realistic GitHub API response shapes, richer diagnostics, and more accurate expectations around queue file cleanup and retries.
- Update logging and worker API documentation examples to use public crate paths and accurate return semantics.
- Relax expectations in error-path tests to allow multiple HTTP attempts while still asserting non-commit behaviour.

Build:
- Switch test and coverage targets to use cargo-nextest for primary execution and llvm-cov integration, add separate cucumber runs, and scope clippy and test invocations to the workspace.
- Update markdown linting and Mermaid diagram validation commands to use markdownlint-cli2 and a sandbox-free nixie invocation.

Tests:
- Strengthen daemon worker tests with improved mock server expectations, richer diagnostics on timeouts, and clearer pass/fail messaging.
- Ensure timeout configuration tests exercise all complexity variants without relying on drop semantics.
- Adjust workflow tests to embed expected actions directly into YAML fixtures for clearer assertions.