### PR TITLE
Add dry-run mode to release workflow and update Linux packaging

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,13 @@
+---
+name: Release Dry Run
+
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.yml
+    with:
+      dry-run: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,19 @@
+---
 name: Release
 
-on:
+'on':
   push:
     tags:
       - 'v*.*.*'
+  workflow_call:
+    inputs:
+      dry-run:
+        description: >-
+          When true, build and package without uploading artefacts or creating
+          a release.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-packages:
@@ -35,19 +45,23 @@ jobs:
       - name: Prepare release version
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0-dev"
+          fi
           echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
       - name: Clean dist directory
         run: rm -rf dist
       - name: Build ${{ matrix.bin }}
-        uses: leynos/shared-actions/.github/actions/rust-build-release@1479e2ffbbf1053bb0205357dfe965299b7493ed
+        uses: leynos/shared-actions/.github/actions/rust-build-release@b3b75715b965ec6c09984a3cea6a725a17bd4107
         with:
           target: ${{ matrix.target }}
           bin-name: ${{ matrix.bin }}
           version: ${{ env.RELEASE_VERSION }}
           formats: deb,rpm
       - name: Package ${{ matrix.bin }}
-        uses: leynos/shared-actions/.github/actions/linux-packages@1479e2ffbbf1053bb0205357dfe965299b7493ed
+        uses: leynos/shared-actions/.github/actions/linux-packages@b3b75715b965ec6c09984a3cea6a725a17bd4107
         with:
           bin-name: ${{ matrix.bin }}
           package-name: ${{ matrix.bin }}
@@ -58,6 +72,7 @@ jobs:
           deb-depends: ${{ env.PACKAGE_DEB_DEPENDS }}
           rpm-depends: ${{ env.PACKAGE_RPM_DEPENDS }}
       - name: Upload artefacts
+        if: ${{ !inputs.dry-run }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.bin }}-${{ matrix.arch }}
@@ -68,6 +83,7 @@ jobs:
             dist/.man/**
           if-no-files-found: error
   release:
+    if: ${{ !inputs.dry-run }}
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs: build-packages


### PR DESCRIPTION
## Summary
- Introduces a dry-run mode for the release workflow to allow non-destructive validation of builds and packaging
- Adds a dedicated Release Dry Run workflow that reuses the main release workflow with dry-run enabled on pull request events
- Improves versioning logic: derive version from vX.Y.Z tags, fallback to 0.0.0-dev for non-tag builds
- Bumps actions for rust-build-release and linux-packages to newer revisions
- Guards artefact upload and GitHub release publishing behind the dry-run flag

## Changes

### CI/CD Workflows
- **.github/workflows/release.yml**:
  - Adds a workflow_call input `dry-run` (boolean, default false)
  - Versioning logic updated to support tag-based and dev builds
  - Upload artefacts and release publishing steps are conditioned on `!inputs.dry-run`
- **.github/workflows/release-dry-run.yml**: (new)
  - Release Dry Run workflow triggered by PR events (opened, synchronize, reopened, ready_for_review)
  - Calls the main release workflow with `dry-run: true` and inherits secrets

### Versioning
- Release versioning now:
  - If GITHUB_REF_NAME matches vX.Y.Z, `RELEASE_VERSION` is the numeric part after `v`
  - Otherwise `RELEASE_VERSION` defaults to `0.0.0-dev`

### Packaging
- Action references updated to newer revisions for:
  - rust-build-release
  - linux-packages
- Packaging still uses the same inputs (bin-name, package-name, etc.) but now in newer tooling revisions

### Release & Artefacts
- Upload artefacts step is skipped during dry-run
- GitHub release publishing is skipped during dry-run

### Tests
- Webhook/PR-based dry-run validation can be tested by opening or updating a PR targeting the branch:
  - Observe that the dry-run workflow runs with `dry-run: true`
  - Build and packaging steps execute, but no artefacts are uploaded
  - The release publishing step is skipped

## Test plan
- [x] Create a PR to trigger the Release Dry Run workflow and verify it calls the main release workflow with dry-run enabled
- [x] Confirm that build and packaging complete without uploading artefacts
- [x] Verify that the GitHub release is not created when in dry-run mode
- [x] Tag a release (e.g., v1.2.3) to ensure the standard release flow still publishes artefacts and creates the release
- [x] Validate that non-tag builds default to 0.0.0-dev in the release version output

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/376cfa58-f5ba-40c0-914e-bceca121bcd8

## Summary by Sourcery

Introduce a dry-runable release workflow and supporting PR-triggered validation flow.

New Features:
- Add a reusable release workflow input to enable dry-run builds without publishing artefacts or creating a GitHub release.
- Create a Release Dry Run workflow that runs on pull requests and invokes the main release workflow in dry-run mode.

Enhancements:
- Update release versioning to derive semantic versions from vX.Y.Z tags and fall back to a 0.0.0-dev version for non-tag builds.
- Bump shared rust-build-release and linux-packages GitHub Actions to newer revisions.
- Guard artefact upload and GitHub release publishing steps behind the dry-run flag.