### PR TITLE
Update shared-actions SHA in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       - name: Install nextest
         uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
         with:
@@ -28,7 +28,7 @@ jobs:
       - name: Test Only
         run: make test
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           output-path: lcov.info
           format: lcov
@@ -36,7 +36,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,14 @@ jobs:
       - name: Clean dist directory
         run: rm -rf dist
       - name: Build ${{ matrix.bin }}
-        uses: leynos/shared-actions/.github/actions/rust-build-release@1479e2ffbbf1053bb0205357dfe965299b7493ed
+        uses: leynos/shared-actions/.github/actions/rust-build-release@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           target: ${{ matrix.target }}
           bin-name: ${{ matrix.bin }}
           version: ${{ env.RELEASE_VERSION }}
           formats: deb,rpm
       - name: Package ${{ matrix.bin }}
-        uses: leynos/shared-actions/.github/actions/linux-packages@1479e2ffbbf1053bb0205357dfe965299b7493ed
+        uses: leynos/shared-actions/.github/actions/linux-packages@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           bin-name: ${{ matrix.bin }}
           package-name: ${{ matrix.bin }}


### PR DESCRIPTION
## Summary
- Update shared-actions SHAs in CI and release workflows to latest commit aebb3f5b831102e2a10ef909c83d7d50ea86c332.

## Changes
### CI: .github/workflows/ci.yml
- Update setup-rust action reference to aebb3f5b831102e2a10ef909c83d7d50ea86c332
- Update generate-coverage action reference to aebb3f5b831102e2a10ef909c83d7d50ea86c332
- Update upload-codescene-coverage action reference to aebb3f5b831102e2a10ef909c83d7d50ea86c332

### Release: .github/workflows/release.yml
- Update rust-build-release action reference to aebb3f5b831102e2a10ef909c83d7d50ea86c332
- Update linux-packages action reference to aebb3f5b831102e2a10ef909c83d7d50ea86c332

## Rationale
- Align workflows with the latest validated shared-actions to ensure compatibility and up-to-date behavior.

## Verification
- This PR changes only workflow SHAs; no code changes.
- CI should pick up the new SHAs on the next workflow run.

## Test plan
- Open PR to trigger CI and release workflows and verify all steps complete successfully.
- If possible, re-run workflows to confirm stability with the new SHAs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/eacf1f81-8f7b-41ab-b4e2-4a31371ddddc

## Summary by Sourcery

Update GitHub Actions workflows to use the latest shared-actions commit for Rust CI and release pipelines.

Build:
- Bump shared-actions commit SHAs in CI workflow for Rust setup, coverage generation, and CodeScene upload steps.
- Align release workflow Rust build and Linux packaging steps to the latest shared-actions commit SHA.