### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
         run: make check-fmt
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Test Only
         run: make test
       - name: Test and Measure Coverage

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,43 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "5 10 * * *" # Daily, 10:05 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    with:
+      # The root comenq-lib crate lives under src/; the comenq client
+      # and comenqd daemon crates live under crates/. The vendored
+      # vendor/filetime patch crate is not a workspace member and is
+      # not a mutation target.
+      paths: "src/,crates/"
+      # test-support and crates/test-utils are test-helper crates whose
+      # survivors are noise.
+      exclude-globs: "test-support/**,crates/test-utils/**"
+      # Match the CI baseline: `make test` runs workspace-wide with
+      # --all-features, and library crates are covered by dependent
+      # crates' integration and cucumber tests, so cargo-mutants must
+      # run the whole workspace's tests against each mutant.
+      extra-args: "--all-features --test-workspace=true"

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -36,8 +36,11 @@ jobs:
       # test-support and crates/test-utils are test-helper crates whose
       # survivors are noise.
       exclude-globs: "test-support/**,crates/test-utils/**"
-      # Match the CI baseline: `make test` runs workspace-wide with
-      # --all-features, and library crates are covered by dependent
-      # crates' integration and cucumber tests, so cargo-mutants must
-      # run the whole workspace's tests against each mutant.
-      extra-args: "--all-features --test-workspace=true"
+      # --workspace: the root manifest is itself a package, so without
+      # it cargo-mutants would mutate only comenq-lib and skip the
+      # crates/ members. The remaining args match the CI baseline:
+      # `make test` runs workspace-wide with --all-features, and
+      # library crates are covered by dependent crates' integration
+      # and cucumber tests, so cargo-mutants must run the whole
+      # workspace's tests against each mutant.
+      extra-args: "--workspace --all-features --test-workspace=true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage/
+__pycache__/
 target/
 **/*.rs.bk
 **/*~

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test test-cov test-cov-lcov build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test test-cov test-cov-lcov test-workflow-contracts build release lint fmt check-fmt markdownlint nixie
 
 APP ?= comenq
 CARGO ?= cargo
@@ -47,6 +47,9 @@ test-cov-lcov: ## Run workspace-wide tests with coverage and write LCOV to cover
 	mkdir -p coverage
 	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov nextest --workspace --all-features --lcov --output-path coverage/lcov.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
 	RUSTFLAGS="-D warnings" $(CARGO) llvm-cov --no-clean --workspace --all-features --test cucumber --lcov --output-path coverage/lcov-cucumber.info --fail-under-lines $(COV_MIN) $(BUILD_JOBS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -30,7 +30,9 @@ EXPECTED_USES = (
 )
 
 #: The exact caller configuration: the root comenq-lib crate plus the
-#: crates/ workspace members are mutation targets; the test-support and
+#: crates/ workspace members are mutation targets (--workspace, because
+#: the root manifest is itself a package so cargo-mutants would
+#: otherwise mutate only comenq-lib); the test-support and
 #: crates/test-utils helper crates are excluded as scaffolding; and the
 #: baseline mirrors CI (workspace-wide, --all-features) so library
 #: crates covered by dependent crates' tests do not report false
@@ -38,7 +40,7 @@ EXPECTED_USES = (
 EXPECTED_WITH = {
     "paths": "src/,crates/",
     "exclude-globs": "test-support/**,crates/test-utils/**",
-    "extra-args": "--all-features --test-workspace=true",
+    "extra-args": "--workspace --all-features --test-workspace=true",
 }
 
 

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,145 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; comenq's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the workspace-wide test
+configuration) fails CI on the pull request rather than surfacing in a
+scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The leynos/shared-actions commit the caller pins. Bump the workflow
+#: and this constant together.
+PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: the root comenq-lib crate plus the
+#: crates/ workspace members are mutation targets; the test-support and
+#: crates/test-utils helper crates are excluded as scaffolding; and the
+#: baseline mirrors CI (workspace-wide, --all-features) so library
+#: crates covered by dependent crates' tests do not report false
+#: survivors.
+EXPECTED_WITH = {
+    "paths": "src/,crates/",
+    "exclude-globs": "test-support/**,crates/test-utils/**",
+    "extra-args": "--all-features --test-workspace=true",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the workflow and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "5 10 * * *"}], (
+        f"on.schedule must be the daily 10:05 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the documented comenq configuration."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented comenq "
+        f"configuration {EXPECTED_WITH!r}, got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request enrols comenq in the estate-wide mutation-testing rollout. It adds a thin caller of the `leynos/shared-actions` [mutation-cargo.yml](https://github.com/leynos/shared-actions/blob/main/.github/workflows/mutation-cargo.yml) reusable workflow, pinned to commit `859416a90eb3987b46a57682c5d6b8964ad3f0a6`. Runs are informational only: a daily scheduled guard (10:05 UTC) mutates files changed within the detection window, while manual dispatch runs mutate everything, fanned out across shards. The pattern follows the estate template established in [leynos/wireframe#572](https://github.com/leynos/wireframe/pull/572); the caller guide is [docs/mutation-cargo-workflow.md](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md).

## Configuration for this repository

- `paths: "src/,crates/"` — the root `comenq-lib` crate lives under `src/`, and the `comenq` client and `comenqd` daemon crates live under `crates/`. The vendored `vendor/filetime` patch crate is not a workspace member and is not a mutation target.
- `exclude-globs: "test-support/**,crates/test-utils/**"` — both are test-helper crates; mutants surviving in scaffolding would be noise.
- `extra-args: "--workspace --all-features --test-workspace=true"` — `--workspace` makes every workspace member a mutation target (the root manifest is itself a package, so cargo-mutants would otherwise mutate only `comenq-lib`; identified by the Codex review). The remaining args mirror the CI baseline (`make test` runs workspace-wide with `--all-features`), and `--test-workspace=true` makes cargo-mutants run the whole workspace's tests against each mutant; without it, library crates covered by dependent crates' integration and cucumber tests would report false survivors.
- No `setup-commands` — `.cargo/config.toml` only carries the `filetime` vendored patch; no custom linker is configured.

## Files

- [.github/workflows/mutation-testing.yml](https://github.com/leynos/comenq/blob/add-mutation-testing/.github/workflows/mutation-testing.yml) — the caller.
- [tests/workflow_contracts/mutation_testing_test.py](https://github.com/leynos/comenq/blob/add-mutation-testing/tests/workflow_contracts/mutation_testing_test.py) — contract tests pinning the SHA, permissions, concurrency, triggers, and the exact `with:` block.
- [Makefile](https://github.com/leynos/comenq/blob/add-mutation-testing/Makefile) — new `test-workflow-contracts` target.
- [.github/workflows/ci.yml](https://github.com/leynos/comenq/blob/add-mutation-testing/.github/workflows/ci.yml) — Setup uv and Workflow contract tests steps after Lint.
- [.gitignore](https://github.com/leynos/comenq/blob/add-mutation-testing/.gitignore) — ignores `__pycache__/`.

## Validation

- Both workflows parse with PyYAML and pass actionlint.
- `make test-workflow-contracts`: 6 passed.
- Negative pin test: repointing the `uses:` reference at `@v1` fails `test_uses_reference_is_pinned_to_the_documented_sha`; restoring the SHA returns the suite to green.
- Baseline verification: `cargo test --workspace --all-features` (plain `cargo test`, the way cargo-mutants runs the baseline with `--test-workspace=true`) was run locally. All unit and integration test targets pass. The cucumber target and six watcher-using daemon tests initially failed with `Too many open files` from `inotify_init` in yaque's watcher — an artefact of the shared build machine, where unrelated processes held 124 of the 128 per-user inotify instances. Each failing daemon test passes when re-run with headroom, and CI already runs the cucumber target under plain `cargo test` (see `make test`) and is green, so no isolation-dependent (nextest-versus-`cargo test`) hazard exists and the mutation baseline is expected to pass on GitHub-hosted runners.

The release dry-run required checks are unaffected: this change adds only workflow and test files, so the cargo build matrix is unchanged.
