### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@v5
       - name: Setup Rust
@@ -23,6 +24,24 @@ jobs:
           tool: nextest@0.9.114
       - name: Format
         run: make check-fmt
+      - name: Cache Whitaker installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install Whitaker Dylint suite
+        run: |
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
+          fi
+          whitaker-installer
       - name: Lint
         run: make lint
       - name: Test Only

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -16,6 +16,7 @@
     "**/target/**",
     "**/.terraform/**",
     "**/.uv-cache/**",
+    "vendor/**",
     "CRUSH.md"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
 name = "comenq-lib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "comenq",
  "comenqd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 cucumber = "0.20"
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --workspace --all-targets --all-features -- -D warnings
 MDLINT ?= markdownlint-cli2
+WHITAKER ?= whitaker
 NIXIE ?= nixie
 COV_MIN ?= 0 # Minimum line coverage percentage for coverage targets
 
@@ -51,8 +52,9 @@ test-cov-lcov: ## Run workspace-wide tests with coverage and write LCOV to cover
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
-lint: ## Run Clippy with warnings denied
+lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTFLAGS="-D warnings" $(WHITAKER) --all -- --all-targets --all-features
 
 fmt: ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
@@ -65,7 +67,7 @@ markdownlint: ## Lint Markdown files
 	$(MDLINT) "**/*.md"
 
 nixie: ## Validate Mermaid diagrams
-	$(NIXIE) --no-sandbox "**/*.md"
+	$(NIXIE) --no-sandbox
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -22,6 +22,3 @@ tracing = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 tempfile = { workspace = true }
-
-[build-dependencies]
-thiserror = { workspace = true }

--- a/crates/comenq/Cargo.toml
+++ b/crates/comenq/Cargo.toml
@@ -22,3 +22,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 tempfile = { workspace = true }
+
+[build-dependencies]
+thiserror = { workspace = true }

--- a/crates/comenq/build.rs
+++ b/crates/comenq/build.rs
@@ -8,27 +8,14 @@ fn main() {
 }
 
 /// Describes why staging the man page failed.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 enum StageError {
     /// A required Cargo environment variable was missing or invalid.
+    #[error("environment variable {0}: {1}")]
     Env(&'static str, std::env::VarError),
     /// Copying the man page into `OUT_DIR` failed.
-    Io(std::io::Error),
-}
-
-impl std::fmt::Display for StageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Env(name, source) => write!(f, "environment variable {name}: {source}"),
-            Self::Io(source) => write!(f, "copy failed: {source}"),
-        }
-    }
-}
-
-impl From<std::io::Error> for StageError {
-    fn from(source: std::io::Error) -> Self {
-        Self::Io(source)
-    }
+    #[error("copy failed: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// Reads a Cargo-provided environment variable, reporting which one failed.

--- a/crates/comenq/build.rs
+++ b/crates/comenq/build.rs
@@ -7,10 +7,39 @@ fn main() {
     }
 }
 
-fn copy_man_page() -> std::io::Result<()> {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+/// Describes why staging the man page failed.
+#[derive(Debug)]
+enum StageError {
+    /// A required Cargo environment variable was missing or invalid.
+    Env(&'static str, std::env::VarError),
+    /// Copying the man page into `OUT_DIR` failed.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for StageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Env(name, source) => write!(f, "environment variable {name}: {source}"),
+            Self::Io(source) => write!(f, "copy failed: {source}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for StageError {
+    fn from(source: std::io::Error) -> Self {
+        Self::Io(source)
+    }
+}
+
+/// Reads a Cargo-provided environment variable, reporting which one failed.
+fn cargo_env(name: &'static str) -> Result<String, StageError> {
+    env::var(name).map_err(|source| StageError::Env(name, source))
+}
+
+fn copy_man_page() -> Result<(), StageError> {
+    let manifest_dir = PathBuf::from(cargo_env("CARGO_MANIFEST_DIR")?);
     let source = manifest_dir.join("../../packaging/man/comenq.1");
-    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+    let out_dir = PathBuf::from(cargo_env("OUT_DIR")?);
     let dest = out_dir.join("comenq.1");
     fs::copy(&source, &dest)?;
     println!("cargo:rerun-if-changed={}", source.display());

--- a/crates/comenq/build.rs
+++ b/crates/comenq/build.rs
@@ -8,14 +8,27 @@ fn main() {
 }
 
 /// Describes why staging the man page failed.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 enum StageError {
     /// A required Cargo environment variable was missing or invalid.
-    #[error("environment variable {0}: {1}")]
     Env(&'static str, std::env::VarError),
     /// Copying the man page into `OUT_DIR` failed.
-    #[error("copy failed: {0}")]
-    Io(#[from] std::io::Error),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for StageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Env(name, source) => write!(f, "environment variable {name}: {source}"),
+            Self::Io(source) => write!(f, "copy failed: {source}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for StageError {
+    fn from(source: std::io::Error) -> Self {
+        Self::Io(source)
+    }
 }
 
 /// Reads a Cargo-provided environment variable, reporting which one failed.

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -42,6 +42,3 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
 default = []
 # Enable helpers from the `test-support` crate for integration tests.
 test-support = ["dep:test-support"]
-
-[build-dependencies]
-thiserror = { workspace = true }

--- a/crates/comenqd/Cargo.toml
+++ b/crates/comenqd/Cargo.toml
@@ -42,3 +42,6 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
 default = []
 # Enable helpers from the `test-support` crate for integration tests.
 test-support = ["dep:test-support"]
+
+[build-dependencies]
+thiserror = { workspace = true }

--- a/crates/comenqd/build.rs
+++ b/crates/comenqd/build.rs
@@ -8,27 +8,14 @@ fn main() {
 }
 
 /// Describes why staging the man page failed.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 enum StageError {
     /// A required Cargo environment variable was missing or invalid.
+    #[error("environment variable {0}: {1}")]
     Env(&'static str, std::env::VarError),
     /// Copying the man page into `OUT_DIR` failed.
-    Io(std::io::Error),
-}
-
-impl std::fmt::Display for StageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Env(name, source) => write!(f, "environment variable {name}: {source}"),
-            Self::Io(source) => write!(f, "copy failed: {source}"),
-        }
-    }
-}
-
-impl From<std::io::Error> for StageError {
-    fn from(source: std::io::Error) -> Self {
-        Self::Io(source)
-    }
+    #[error("copy failed: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// Reads a Cargo-provided environment variable, reporting which one failed.

--- a/crates/comenqd/build.rs
+++ b/crates/comenqd/build.rs
@@ -7,10 +7,39 @@ fn main() {
     }
 }
 
-fn copy_man_page() -> std::io::Result<()> {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+/// Describes why staging the man page failed.
+#[derive(Debug)]
+enum StageError {
+    /// A required Cargo environment variable was missing or invalid.
+    Env(&'static str, std::env::VarError),
+    /// Copying the man page into `OUT_DIR` failed.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for StageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Env(name, source) => write!(f, "environment variable {name}: {source}"),
+            Self::Io(source) => write!(f, "copy failed: {source}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for StageError {
+    fn from(source: std::io::Error) -> Self {
+        Self::Io(source)
+    }
+}
+
+/// Reads a Cargo-provided environment variable, reporting which one failed.
+fn cargo_env(name: &'static str) -> Result<String, StageError> {
+    env::var(name).map_err(|source| StageError::Env(name, source))
+}
+
+fn copy_man_page() -> Result<(), StageError> {
+    let manifest_dir = PathBuf::from(cargo_env("CARGO_MANIFEST_DIR")?);
     let source = manifest_dir.join("../../packaging/man/comenqd.1");
-    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+    let out_dir = PathBuf::from(cargo_env("OUT_DIR")?);
     let dest = out_dir.join("comenqd.1");
     fs::copy(&source, &dest)?;
     println!("cargo:rerun-if-changed={}", source.display());

--- a/crates/comenqd/build.rs
+++ b/crates/comenqd/build.rs
@@ -8,14 +8,27 @@ fn main() {
 }
 
 /// Describes why staging the man page failed.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 enum StageError {
     /// A required Cargo environment variable was missing or invalid.
-    #[error("environment variable {0}: {1}")]
     Env(&'static str, std::env::VarError),
     /// Copying the man page into `OUT_DIR` failed.
-    #[error("copy failed: {0}")]
-    Io(#[from] std::io::Error),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for StageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Env(name, source) => write!(f, "environment variable {name}: {source}"),
+            Self::Io(source) => write!(f, "copy failed: {source}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for StageError {
+    fn from(source: std::io::Error) -> Self {
+        Self::Io(source)
+    }
 }
 
 /// Reads a Cargo-provided environment variable, reporting which one failed.

--- a/crates/comenqd/src/daemon.rs
+++ b/crates/comenqd/src/daemon.rs
@@ -22,12 +22,13 @@ pub use crate::worker::{WorkerControl, WorkerHooks};
 #[doc(hidden)]
 pub use crate::util::is_metadata_file;
 
-/// Listener utilities for accepting client connections.
-///
-/// Re-exports selected listener APIs (functions and constants) so integration
-/// tests can exercise socket preparation, client handling, and read limits
-/// without exposing the entire `listener` module publicly.
 pub mod listener {
+    //! Listener utilities for accepting client connections.
+    //!
+    //! Re-exports selected listener APIs (functions and constants) so
+    //! integration tests can exercise socket preparation, client handling,
+    //! and read limits without exposing the entire `listener` module
+    //! publicly.
     // Keep manual ordering so integration tests import the public API consistently.
     #[rustfmt::skip]
     pub use crate::listener::{

--- a/crates/comenqd/src/listener.rs
+++ b/crates/comenqd/src/listener.rs
@@ -111,7 +111,7 @@ pub async fn run_listener(
                     tracing::error!(error = %e, "Failed to accept client connection");
                     let delay = accept_backoff
                         .next()
-                        .expect("backoff should yield a duration");
+                        .unwrap_or(crate::supervisor::BACKOFF_FALLBACK_DELAY);
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {},
                         _ = shutdown.changed() => break,

--- a/crates/comenqd/src/supervisor.rs
+++ b/crates/comenqd/src/supervisor.rs
@@ -35,6 +35,12 @@ pub async fn ensure_queue_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Fallback delay used if a backoff iterator is unexpectedly exhausted.
+///
+/// The builders here never cap attempts, so exhaustion should not occur;
+/// the fallback keeps restart pacing sane without panicking.
+pub(crate) const BACKOFF_FALLBACK_DELAY: Duration = Duration::from_secs(1);
+
 /// Build a jittered exponential backoff with no maximum attempt count.
 ///
 /// The minimum delay is provided by the caller to allow environment-specific
@@ -86,9 +92,7 @@ async fn supervise_task<F, B>(
                     break;
                 }
                 log_task_failure(name, &res);
-                let delay = backoff
-                    .next()
-                    .expect("backoff should yield a duration");
+                let delay = backoff.next().unwrap_or(BACKOFF_FALLBACK_DELAY);
                 if sleep_or_shutdown(&mut shutdown, delay).await {
                     break;
                 }
@@ -131,7 +135,7 @@ async fn supervise_writer<B>(
                         pair.1
                     }
                 };
-                let delay = backoff.next().expect("backoff should yield a duration");
+                let delay = backoff.next().unwrap_or(BACKOFF_FALLBACK_DELAY);
                 if sleep_or_shutdown(&mut shutdown, delay).await {
                     break;
                 }

--- a/crates/comenqd/tests/daemon.rs
+++ b/crates/comenqd/tests/daemon.rs
@@ -230,7 +230,7 @@ mod worker_tests {
             .expect(1..) // Expect at least one request
             .mount(&server)
             .await;
-        let octo = octocrab_for(&server);
+        let octo = octocrab_for(&server).expect("octocrab client should build for the mock server");
         WorkerTestContext {
             server,
             cfg,
@@ -422,7 +422,7 @@ mod worker_tests {
         // Create empty queue - worker will block on recv()
         let (_sender, rx) = channel(&cfg.queue_path).expect("channel");
         let server = MockServer::start().await;
-        let octo = octocrab_for(&server);
+        let octo = octocrab_for(&server).expect("octocrab client should build for the mock server");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let control = WorkerControl {
@@ -479,7 +479,7 @@ mod worker_tests {
             .expect(1)
             .mount(&server)
             .await;
-        let octo = octocrab_for(&server);
+        let octo = octocrab_for(&server).expect("octocrab client should build for the mock server");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let idle = Arc::new(Notify::new());
@@ -535,7 +535,7 @@ mod worker_tests {
 
         let server = MockServer::start().await;
         // No mock needed - malformed message won't reach GitHub API
-        let octo = octocrab_for(&server);
+        let octo = octocrab_for(&server).expect("octocrab client should build for the mock server");
 
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let idle = Arc::new(Notify::new());

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,0 +1,21 @@
+# Configuration for the Whitaker Dylint suite.
+#
+# Crates excluded from the no_std_fs_operations lint because they legitimately
+# require ambient std::fs access:
+# - build_script_build: the build scripts stage packaged man pages into
+#   Cargo's OUT_DIR; they run in Cargo's ambient environment by design, so
+#   capability-based handles offer no benefit.
+# - comenqd: the daemon prepares its Unix domain socket (permissions, atomic
+#   rename, stale-socket removal) and inspects its yaque queue directory at
+#   operator-configured absolute paths supplied by systemd-style
+#   configuration; this ambient access is intrinsic to the daemon's role.
+# - cucumber: the behavioural test crate; step fixtures write configuration
+#   files and packaging manifests inside ambient tempdirs, which the Whitaker
+#   user's guide lists as a sanctioned exclusion category (test support
+#   utilities).
+[no_std_fs_operations]
+excluded_crates = [
+    "build_script_build",
+    "comenqd",
+    "cucumber",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub struct CommentRequest {
 
 #[cfg(test)]
 mod tests {
+    //! Unit tests for [`CommentRequest`] serialisation.
     use super::CommentRequest;
     use serde_json::{self, json};
 

--- a/test-support/src/daemon.rs
+++ b/test-support/src/daemon.rs
@@ -110,17 +110,21 @@ impl TestConfig {
 ///
 /// The client is initialised with a placeholder token and its base URL
 /// configured to the mock server's URI.
-#[expect(
-    clippy::expect_used,
-    reason = "test helper prefers descriptive panics over unwrap"
-)]
-pub fn octocrab_for(server: &MockServer) -> Arc<Octocrab> {
-    Arc::new(
+///
+/// # Errors
+///
+/// Returns an error when the mock server URI cannot be parsed or the client
+/// cannot be built.
+///
+/// The error is boxed to keep the `Err` variant small
+/// (`clippy::result_large_err`).
+pub fn octocrab_for(server: &MockServer) -> Result<Arc<Octocrab>, Box<octocrab::Error>> {
+    Ok(Arc::new(
         Octocrab::builder()
             .personal_token(String::from("t"))
             .base_uri(server.uri())
-            .expect("failed to parse MockServer URI for Octocrab base_uri")
+            .map_err(Box::new)?
             .build()
-            .expect("failed to build Octocrab client"),
-    )
+            .map_err(Box::new)?,
+    ))
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -11,11 +11,14 @@ use steps::{
 };
 
 fn main() -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
     // Build the runtime explicitly so runtime construction errors propagate
     // instead of panicking inside the `#[tokio::main]` expansion.
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .build()?;
+        .build()
+        .context("failed to build the Tokio runtime for the cucumber test binary")?;
     runtime.block_on(async {
         tokio::join!(
             CliWorld::run("tests/features/cli.feature"),

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -10,16 +10,23 @@ use steps::{
     WorkerWorld,
 };
 
-#[tokio::main]
-async fn main() {
-    tokio::join!(
-        CliWorld::run("tests/features/cli.feature"),
-        ReleaseWorld::run("tests/features/release.feature"),
-        ClientWorld::run("tests/features/client_main.feature"),
-        CommentWorld::run("tests/features/comment_request.feature"),
-        ConfigWorld::run("tests/features/config.feature"),
-        ListenerWorld::run("tests/features/listener.feature"),
-        PackagingWorld::run("tests/features/packaging.feature"),
-        WorkerWorld::run("tests/features/worker.feature"),
-    );
+fn main() -> anyhow::Result<()> {
+    // Build the runtime explicitly so runtime construction errors propagate
+    // instead of panicking inside the `#[tokio::main]` expansion.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(async {
+        tokio::join!(
+            CliWorld::run("tests/features/cli.feature"),
+            ReleaseWorld::run("tests/features/release.feature"),
+            ClientWorld::run("tests/features/client_main.feature"),
+            CommentWorld::run("tests/features/comment_request.feature"),
+            ConfigWorld::run("tests/features/config.feature"),
+            ListenerWorld::run("tests/features/listener.feature"),
+            PackagingWorld::run("tests/features/packaging.feature"),
+            WorkerWorld::run("tests/features/worker.feature"),
+        );
+    });
+    Ok(())
 }

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -4,6 +4,7 @@
 //! invalid command line inputs, including the optional `--socket`
 //! flag. They ensure the parser surface behaves as documented.
 
+use anyhow::Context as _;
 use clap::Parser;
 use cucumber::{World, given, then, when};
 use std::ffi::OsString;
@@ -52,13 +53,13 @@ fn socket_path(world: &mut CliWorld, path: String) {
 }
 
 #[when("they are parsed")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn they_are_parsed(world: &mut CliWorld) {
+fn they_are_parsed(world: &mut CliWorld) -> anyhow::Result<()> {
     let args = world
         .args
         .clone()
-        .expect("world.args should be set by a given step");
+        .context("world.args should be set by a given step")?;
     world.result = Some(Args::try_parse_from(args));
+    Ok(())
 }
 
 #[then("parsing succeeds")]

--- a/tests/steps/client_main_steps.rs
+++ b/tests/steps/client_main_steps.rs
@@ -16,6 +16,16 @@ pub struct ClientWorld {
     result: Option<Result<(), ClientError>>,
 }
 
+/// Build the default client arguments targeting `socket`.
+fn base_args(socket: std::path::PathBuf) -> anyhow::Result<Args> {
+    Ok(Args {
+        repo_slug: "octocat/hello-world".parse().context("slug")?,
+        pr_number: 1,
+        comment_body: "Hi".into(),
+        socket,
+    })
+}
+
 #[given("a dummy daemon listening on a socket")]
 fn dummy_daemon(world: &mut ClientWorld) -> anyhow::Result<()> {
     let dir = TempDir::new().context("tempdir")?;
@@ -29,12 +39,7 @@ fn dummy_daemon(world: &mut ClientWorld) -> anyhow::Result<()> {
         Ok(buf)
     });
 
-    world.args = Some(Args {
-        repo_slug: "octocat/hello-world".parse().context("slug")?,
-        pr_number: 1,
-        comment_body: "Hi".into(),
-        socket: socket.clone(),
-    });
+    world.args = Some(base_args(socket)?);
     world.tempdir = Some(dir);
     world.server = Some(handle);
     Ok(())
@@ -44,12 +49,7 @@ fn dummy_daemon(world: &mut ClientWorld) -> anyhow::Result<()> {
 fn no_daemon(world: &mut ClientWorld) -> anyhow::Result<()> {
     let dir = TempDir::new().context("tempdir")?;
     let socket = dir.path().join("sock");
-    world.args = Some(Args {
-        repo_slug: "octocat/hello-world".parse().context("slug")?,
-        pr_number: 1,
-        comment_body: "Hi".into(),
-        socket,
-    });
+    world.args = Some(base_args(socket)?);
     world.tempdir = Some(dir);
     Ok(())
 }

--- a/tests/steps/client_main_steps.rs
+++ b/tests/steps/client_main_steps.rs
@@ -1,5 +1,6 @@
 //! Behavioural test steps for the client binary's interaction with the daemon.
 
+use anyhow::Context as _;
 use comenq::{Args, ClientError, run};
 use comenq_lib::CommentRequest;
 use cucumber::{World, given, then, when};
@@ -11,70 +12,67 @@ use tokio::net::UnixListener;
 pub struct ClientWorld {
     args: Option<Args>,
     tempdir: Option<TempDir>,
-    server: Option<tokio::task::JoinHandle<Vec<u8>>>,
+    server: Option<tokio::task::JoinHandle<anyhow::Result<Vec<u8>>>>,
     result: Option<Result<(), ClientError>>,
 }
 
 #[given("a dummy daemon listening on a socket")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn dummy_daemon(world: &mut ClientWorld) {
-    let dir = TempDir::new().expect("tempdir");
+fn dummy_daemon(world: &mut ClientWorld) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("tempdir")?;
     let socket = dir.path().join("sock");
-    let listener = UnixListener::bind(&socket).expect("bind");
+    let listener = UnixListener::bind(&socket).context("bind")?;
 
     let handle = tokio::spawn(async move {
-        let (mut stream, _) = listener.accept().await.expect("accept");
+        let (mut stream, _) = listener.accept().await.context("accept")?;
         let mut buf = Vec::new();
-        stream.read_to_end(&mut buf).await.expect("read");
-        buf
+        stream.read_to_end(&mut buf).await.context("read")?;
+        Ok(buf)
     });
 
     world.args = Some(Args {
-        repo_slug: "octocat/hello-world".parse().expect("slug"),
+        repo_slug: "octocat/hello-world".parse().context("slug")?,
         pr_number: 1,
         comment_body: "Hi".into(),
         socket: socket.clone(),
     });
     world.tempdir = Some(dir);
     world.server = Some(handle);
+    Ok(())
 }
 
 #[given("no daemon is listening on a socket")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn no_daemon(world: &mut ClientWorld) {
-    let dir = TempDir::new().expect("tempdir");
+fn no_daemon(world: &mut ClientWorld) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("tempdir")?;
     let socket = dir.path().join("sock");
     world.args = Some(Args {
-        repo_slug: "octocat/hello-world".parse().expect("slug"),
+        repo_slug: "octocat/hello-world".parse().context("slug")?,
         pr_number: 1,
         comment_body: "Hi".into(),
         socket,
     });
     world.tempdir = Some(dir);
+    Ok(())
 }
 
 #[when("the client sends the request")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-async fn send_request(world: &mut ClientWorld) {
-    let args = world.args.clone().expect("args");
+async fn send_request(world: &mut ClientWorld) -> anyhow::Result<()> {
+    let args = world.args.clone().context("args")?;
     world.result = Some(run(args).await);
+    Ok(())
 }
 
 #[then("the daemon receives the request")]
-#[expect(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "simplify test failure output"
-)]
-async fn daemon_receives(world: &mut ClientWorld) {
-    let handle = world.server.take().expect("server handle");
-    let data = handle.await.expect("join");
-    let req: CommentRequest = serde_json::from_slice(&data).expect("parse");
+async fn daemon_receives(world: &mut ClientWorld) -> anyhow::Result<()> {
+    let handle = world.server.take().context("server handle")?;
+    let data = handle.await.context("join")??;
+    let req: CommentRequest = serde_json::from_slice(&data).context("parse")?;
     assert_eq!(req.owner, "octocat");
     assert_eq!(req.repo, "hello-world");
     assert_eq!(req.pr_number, 1);
     assert_eq!(req.body, "Hi");
-    assert!(world.result.take().unwrap().is_ok());
+    let result = world.result.take().context("client result recorded")?;
+    assert!(result.is_ok());
+    Ok(())
 }
 
 #[then("an error occurs")]

--- a/tests/steps/comment_steps.rs
+++ b/tests/steps/comment_steps.rs
@@ -1,5 +1,6 @@
 //! Behavioural test steps for comment request serialisation and parsing.
 
+use anyhow::Context as _;
 use comenq_lib::CommentRequest;
 use cucumber::{World, given, then, when};
 
@@ -21,21 +22,20 @@ fn a_default_comment_request(world: &mut CommentWorld) {
 }
 
 #[when("it is serialised")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn it_is_serialised(world: &mut CommentWorld) {
+fn it_is_serialised(world: &mut CommentWorld) -> anyhow::Result<()> {
     if let Some(req) = world.request.take() {
         world.json =
-            Some(serde_json::to_string(&req).expect("serialisation should succeed in test"));
+            Some(serde_json::to_string(&req).context("serialisation should succeed in test")?);
     }
+    Ok(())
 }
 
 #[then("the JSON is correct")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn the_json_is(world: &mut CommentWorld) {
+fn the_json_is(world: &mut CommentWorld) -> anyhow::Result<()> {
     match world.json.take() {
         Some(actual) => {
             let act: serde_json::Value =
-                serde_json::from_str(&actual).expect("test JSON should parse successfully");
+                serde_json::from_str(&actual).context("test JSON should parse successfully")?;
             let exp = serde_json::json!({
                 "owner": "octocat",
                 "repo": "hello-world",
@@ -46,6 +46,7 @@ fn the_json_is(world: &mut CommentWorld) {
         }
         None => panic!("missing JSON output - test setup error"),
     }
+    Ok(())
 }
 
 #[given("invalid JSON")]

--- a/tests/steps/config_steps.rs
+++ b/tests/steps/config_steps.rs
@@ -18,15 +18,21 @@ pub struct ConfigWorld {
     socket_guard: Option<EnvVarGuard>,
 }
 
+/// Create a tempdir containing a `config.toml` with `content`.
+fn write_temp_config(content: &str) -> anyhow::Result<(TempDir, PathBuf)> {
+    let dir = TempDir::new().context("create temp dir")?;
+    let path = dir.path().join("config.toml");
+    fs::write(&path, content).context("write file")?;
+    Ok((dir, path))
+}
+
 #[given(regex = r#"^a configuration file with token \"(.+)\"$"#)]
 #[expect(
     clippy::needless_pass_by_value,
     reason = "cucumber requires owned values"
 )]
 fn config_file_with_token(world: &mut ConfigWorld, token: String) -> anyhow::Result<()> {
-    let dir = TempDir::new().context("create temp dir")?;
-    let path = dir.path().join("config.toml");
-    fs::write(&path, format!("github_token='{token}'")).context("write file")?;
+    let (dir, path) = write_temp_config(&format!("github_token='{token}'"))?;
     world.dir = Some(dir);
     world.path = Some(path);
     world.socket_guard = Some(EnvVarGuard::remove("COMENQD_SOCKET_PATH"));
@@ -35,9 +41,7 @@ fn config_file_with_token(world: &mut ConfigWorld, token: String) -> anyhow::Res
 
 #[given("an invalid configuration file")]
 fn invalid_configuration_file(world: &mut ConfigWorld) -> anyhow::Result<()> {
-    let dir = TempDir::new().context("create temp dir")?;
-    let path = dir.path().join("config.toml");
-    fs::write(&path, "github_token='abc' this is not toml").context("write file")?;
+    let (dir, path) = write_temp_config("github_token='abc' this is not toml")?;
     world.dir = Some(dir);
     world.path = Some(path);
     Ok(())
@@ -45,9 +49,7 @@ fn invalid_configuration_file(world: &mut ConfigWorld) -> anyhow::Result<()> {
 
 #[given("a configuration file without github_token")]
 fn config_file_without_token(world: &mut ConfigWorld) -> anyhow::Result<()> {
-    let dir = TempDir::new().context("create temp dir")?;
-    let path = dir.path().join("config.toml");
-    fs::write(&path, "socket_path='/tmp/s.sock'").context("write file")?;
+    let (dir, path) = write_temp_config("socket_path='/tmp/s.sock'")?;
     world.dir = Some(dir);
     world.path = Some(path);
     Ok(())
@@ -59,13 +61,7 @@ fn config_file_without_token(world: &mut ConfigWorld) -> anyhow::Result<()> {
     reason = "cucumber requires owned values"
 )]
 fn config_without_socket(world: &mut ConfigWorld, token: String) -> anyhow::Result<()> {
-    let dir = TempDir::new().context("create temp dir")?;
-    let path = dir.path().join("config.toml");
-    fs::write(
-        &path,
-        format!("github_token='{token}'\nqueue_path='/tmp/q'"),
-    )
-    .context("write file")?;
+    let (dir, path) = write_temp_config(&format!("github_token='{token}'\nqueue_path='/tmp/q'"))?;
     world.dir = Some(dir);
     world.path = Some(path);
     world.socket_guard = Some(EnvVarGuard::remove("COMENQD_SOCKET_PATH"));

--- a/tests/steps/config_steps.rs
+++ b/tests/steps/config_steps.rs
@@ -1,5 +1,6 @@
 //! Behavioural steps for daemon configuration loading.
 
+use anyhow::Context as _;
 use cucumber::{World, given, then, when};
 use std::fs;
 use std::path::PathBuf;
@@ -18,62 +19,62 @@ pub struct ConfigWorld {
 }
 
 #[given(regex = r#"^a configuration file with token \"(.+)\"$"#)]
-#[expect(clippy::expect_used, reason = "test setup uses expect")]
 #[expect(
     clippy::needless_pass_by_value,
     reason = "cucumber requires owned values"
 )]
-fn config_file_with_token(world: &mut ConfigWorld, token: String) {
-    let dir = TempDir::new().expect("create temp dir");
+fn config_file_with_token(world: &mut ConfigWorld, token: String) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("create temp dir")?;
     let path = dir.path().join("config.toml");
-    fs::write(&path, format!("github_token='{token}'")).expect("write file");
+    fs::write(&path, format!("github_token='{token}'")).context("write file")?;
     world.dir = Some(dir);
     world.path = Some(path);
     world.socket_guard = Some(EnvVarGuard::remove("COMENQD_SOCKET_PATH"));
+    Ok(())
 }
 
 #[given("an invalid configuration file")]
-#[expect(clippy::expect_used, reason = "test setup uses expect")]
-fn invalid_configuration_file(world: &mut ConfigWorld) {
-    let dir = TempDir::new().expect("create temp dir");
+fn invalid_configuration_file(world: &mut ConfigWorld) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("create temp dir")?;
     let path = dir.path().join("config.toml");
-    fs::write(&path, "github_token='abc' this is not toml").expect("write file");
+    fs::write(&path, "github_token='abc' this is not toml").context("write file")?;
     world.dir = Some(dir);
     world.path = Some(path);
+    Ok(())
 }
 
 #[given("a configuration file without github_token")]
-#[expect(clippy::expect_used, reason = "test setup uses expect")]
-fn config_file_without_token(world: &mut ConfigWorld) {
-    let dir = TempDir::new().expect("create temp dir");
+fn config_file_without_token(world: &mut ConfigWorld) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("create temp dir")?;
     let path = dir.path().join("config.toml");
-    fs::write(&path, "socket_path='/tmp/s.sock'").expect("write file");
+    fs::write(&path, "socket_path='/tmp/s.sock'").context("write file")?;
     world.dir = Some(dir);
     world.path = Some(path);
+    Ok(())
 }
 
 #[given(regex = r#"^a configuration file with token \"(.+)\" and no socket_path$"#)]
-#[expect(clippy::expect_used, reason = "test setup uses expect")]
 #[expect(
     clippy::needless_pass_by_value,
     reason = "cucumber requires owned values"
 )]
-fn config_without_socket(world: &mut ConfigWorld, token: String) {
-    let dir = TempDir::new().expect("create temp dir");
+fn config_without_socket(world: &mut ConfigWorld, token: String) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("create temp dir")?;
     let path = dir.path().join("config.toml");
     fs::write(
         &path,
         format!("github_token='{token}'\nqueue_path='/tmp/q'"),
     )
-    .expect("write file");
+    .context("write file")?;
     world.dir = Some(dir);
     world.path = Some(path);
     world.socket_guard = Some(EnvVarGuard::remove("COMENQD_SOCKET_PATH"));
+    Ok(())
 }
 
 #[given(regex = r#"^a configuration file with token \"(.+)\" and no cooldown_period_seconds$"#)]
-fn config_without_cooldown(world: &mut ConfigWorld, token: String) {
-    config_file_with_token(world, token);
+fn config_without_cooldown(world: &mut ConfigWorld, token: String) -> anyhow::Result<()> {
+    config_file_with_token(world, token)
 }
 
 #[given("a missing configuration file")]
@@ -91,10 +92,10 @@ fn set_env_var(world: &mut ConfigWorld, key: String, value: String) {
 }
 
 #[when("the config is loaded")]
-#[expect(clippy::expect_used, reason = "test assertions")]
-fn load_config(world: &mut ConfigWorld) {
-    let path = world.path.as_ref().expect("path set");
+fn load_config(world: &mut ConfigWorld) -> anyhow::Result<()> {
+    let path = world.path.as_ref().context("path set")?;
     world.result = Some(Config::from_file(path));
+    Ok(())
 }
 
 #[then(regex = r#"^github token is \"(.+)\"$"#)]

--- a/tests/steps/listener_steps.rs
+++ b/tests/steps/listener_steps.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context as _;
 use cucumber::World;
 use cucumber::{given, then, when};
 use tempfile::TempDir;
@@ -33,15 +34,10 @@ impl std::fmt::Debug for ListenerWorld {
 }
 
 #[given("a running listener task")]
-#[expect(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "simplify test failure output"
-)]
-async fn running_listener(world: &mut ListenerWorld) {
-    let dir = TempDir::new().expect("tempdir");
+async fn running_listener(world: &mut ListenerWorld) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("tempdir")?;
     let cfg = Arc::new(Config::from(temp_config(&dir)));
-    let (sender, receiver) = channel(&cfg.queue_path).expect("channel");
+    let (sender, receiver) = channel(&cfg.queue_path).context("channel")?;
     let (client_tx, writer_rx) = mpsc::channel(4);
     let (shutdown_tx, shutdown_rx) = watch::channel(());
     let cfg_clone = cfg.clone();
@@ -51,9 +47,9 @@ async fn running_listener(world: &mut ListenerWorld) {
         let _ = queue_writer(sender, writer_rx).await;
     });
     let handle = tokio::spawn(async move {
-        run_listener(cfg_clone, client_tx, shutdown_rx)
-            .await
-            .unwrap();
+        if let Err(error) = run_listener(cfg_clone, client_tx, shutdown_rx).await {
+            panic!("listener task failed: {error}");
+        }
     });
     world.dir = Some(dir);
     world.cfg = Some(cfg);
@@ -65,71 +61,63 @@ async fn running_listener(world: &mut ListenerWorld) {
     let socket_path = &world
         .cfg
         .as_ref()
-        .expect("config not initialised in ListenerWorld")
+        .context("config not initialised in ListenerWorld")?
         .socket_path;
     assert!(
         wait_for_file(socket_path, SOCKET_RETRY_COUNT, SOCKET_RETRY_DELAY).await,
         "socket file {} not created within timeout",
         socket_path.display()
     );
+    Ok(())
 }
 
 #[when("a client sends a valid request")]
-#[expect(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "simplify test failure output"
-)]
-async fn client_sends_valid(world: &mut ListenerWorld) {
-    let cfg = world.cfg.as_ref().unwrap();
+async fn client_sends_valid(world: &mut ListenerWorld) -> anyhow::Result<()> {
+    let cfg = world.cfg.as_ref().context("config initialised")?;
     let mut stream = UnixStream::connect(&cfg.socket_path)
         .await
-        .expect("connect");
+        .context("connect")?;
     let req = CommentRequest {
         owner: "o".into(),
         repo: "r".into(),
         pr_number: 1,
         body: "b".into(),
     };
-    let data = serde_json::to_vec(&req).unwrap();
-    stream.write_all(&data).await.unwrap();
-    stream.shutdown().await.expect("shutdown");
+    let data = serde_json::to_vec(&req).context("serialise request")?;
+    stream.write_all(&data).await.context("write request")?;
+    stream.shutdown().await.context("shutdown")?;
+    Ok(())
 }
 
 #[when("a client sends invalid JSON")]
-#[expect(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "simplify test failure output"
-)]
-async fn client_sends_invalid(world: &mut ListenerWorld) {
-    let cfg = world.cfg.as_ref().unwrap();
+async fn client_sends_invalid(world: &mut ListenerWorld) -> anyhow::Result<()> {
+    let cfg = world.cfg.as_ref().context("config initialised")?;
     let mut stream = UnixStream::connect(&cfg.socket_path)
         .await
-        .expect("connect");
-    stream.write_all(b"not json").await.unwrap();
-    stream.shutdown().await.expect("shutdown");
+        .context("connect")?;
+    stream
+        .write_all(b"not json")
+        .await
+        .context("write request")?;
+    stream.shutdown().await.context("shutdown")?;
+    Ok(())
 }
 
 #[then("the request is enqueued")]
-#[expect(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "simplify test failure output"
-)]
-async fn request_enqueued(world: &mut ListenerWorld) {
-    let receiver = world.receiver.as_mut().unwrap();
-    let guard = receiver.recv().await.expect("recv");
-    let req: CommentRequest = serde_json::from_slice(&guard).unwrap();
+async fn request_enqueued(world: &mut ListenerWorld) -> anyhow::Result<()> {
+    let receiver = world.receiver.as_mut().context("receiver initialised")?;
+    let guard = receiver.recv().await.context("recv")?;
+    let req: CommentRequest = serde_json::from_slice(&guard).context("parse request")?;
     assert_eq!(req.owner, "o");
+    Ok(())
 }
 
 #[then("the request is rejected")]
-#[expect(clippy::unwrap_used, reason = "simplify test failure output")]
-async fn request_rejected(world: &mut ListenerWorld) {
-    let receiver = world.receiver.as_mut().unwrap();
+async fn request_rejected(world: &mut ListenerWorld) -> anyhow::Result<()> {
+    let receiver = world.receiver.as_mut().context("receiver initialised")?;
     let res = tokio::time::timeout(Duration::from_millis(100), receiver.recv()).await;
     assert!(res.is_err());
+    Ok(())
 }
 
 impl Drop for ListenerWorld {

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -1,3 +1,4 @@
+//! Step definitions shared by the cucumber behavioural test suites.
 pub mod cli_steps;
 pub use cli_steps::CliWorld;
 pub mod client_main_steps;

--- a/tests/steps/packaging_steps.rs
+++ b/tests/steps/packaging_steps.rs
@@ -1,5 +1,6 @@
 //! Behavioural steps for packaging configuration.
 
+use anyhow::Context as _;
 use cucumber::{World, given, then, when};
 use serde_yaml::Value;
 use std::fs;
@@ -11,38 +12,38 @@ pub struct PackagingWorld {
 }
 
 #[given("the goreleaser configuration file")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn the_goreleaser_file(world: &mut PackagingWorld) {
-    let text = fs::read_to_string(".goreleaser.yaml").expect("read goreleaser");
+fn the_goreleaser_file(world: &mut PackagingWorld) -> anyhow::Result<()> {
+    let text = fs::read_to_string(".goreleaser.yaml").context("read goreleaser")?;
     world.content = Some(text);
+    Ok(())
 }
 
 #[when("it is parsed as YAML")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn parse_yaml(world: &mut PackagingWorld) {
-    let text = world.content.take().expect("file loaded");
-    world.yaml = Some(serde_yaml::from_str(&text).expect("parse yaml"));
+fn parse_yaml(world: &mut PackagingWorld) -> anyhow::Result<()> {
+    let text = world.content.take().context("file loaded")?;
+    world.yaml = Some(serde_yaml::from_str(&text).context("parse yaml")?);
+    Ok(())
 }
 
 #[then("the nfpms section exists")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn nfpms_exists(world: &mut PackagingWorld) {
-    let yaml = world.yaml.as_ref().expect("yaml parsed");
+fn nfpms_exists(world: &mut PackagingWorld) -> anyhow::Result<()> {
+    let yaml = world.yaml.as_ref().context("yaml parsed")?;
     assert!(yaml.get("nfpms").is_some(), "missing nfpms section");
+    Ok(())
 }
 
 #[given("the systemd unit file")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn the_systemd_file(world: &mut PackagingWorld) {
-    let text = fs::read_to_string("packaging/linux/comenqd.service").expect("read service");
+fn the_systemd_file(world: &mut PackagingWorld) -> anyhow::Result<()> {
+    let text = fs::read_to_string("packaging/linux/comenqd.service").context("read service")?;
     world.content = Some(text);
+    Ok(())
 }
 
 #[then("it includes hardening directives")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn includes_hardening(world: &mut PackagingWorld) {
-    let text = world.content.take().expect("service loaded");
+fn includes_hardening(world: &mut PackagingWorld) -> anyhow::Result<()> {
+    let text = world.content.take().context("service loaded")?;
     assert!(text.contains("ProtectSystem=strict"));
     assert!(text.contains("PrivateTmp=true"));
     assert!(text.contains("NoNewPrivileges=true"));
+    Ok(())
 }

--- a/tests/steps/release_steps.rs
+++ b/tests/steps/release_steps.rs
@@ -1,5 +1,6 @@
 //! Behavioural steps for the release workflow.
 
+use anyhow::Context as _;
 use cucumber::{World, given, then, when};
 use regex::Regex;
 use serde_yaml::Value;
@@ -13,42 +14,42 @@ pub struct ReleaseWorld {
 }
 
 #[given("the release workflow file")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn the_workflow_file(world: &mut ReleaseWorld) {
-    let text = fs::read_to_string(".github/workflows/release.yml").expect("read workflow");
+fn the_workflow_file(world: &mut ReleaseWorld) -> anyhow::Result<()> {
+    let text = fs::read_to_string(".github/workflows/release.yml").context("read workflow")?;
     world.content = Some(text);
+    Ok(())
 }
 
 #[when("it is parsed as YAML")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn parse_yaml(world: &mut ReleaseWorld) {
-    let text = world.content.as_deref().expect("file loaded");
-    world.yaml = Some(serde_yaml::from_str(text).expect("parse yaml"));
+fn parse_yaml(world: &mut ReleaseWorld) -> anyhow::Result<()> {
+    let text = world.content.as_deref().context("file loaded")?;
+    world.yaml = Some(serde_yaml::from_str(text).context("parse yaml")?);
+    Ok(())
 }
 
 #[then("the workflow uses the shared release actions")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn assert_uses_shared_actions(world: &mut ReleaseWorld) {
-    let content = world.content.as_ref().expect("file still loaded");
-    assert!(workflow_uses_shared_actions(content).expect("parse"));
+fn assert_uses_shared_actions(world: &mut ReleaseWorld) -> anyhow::Result<()> {
+    let content = world.content.as_ref().context("file still loaded")?;
+    assert!(workflow_uses_shared_actions(content).context("parse")?);
+    Ok(())
 }
 
 #[then("the workflow triggers on tags")]
-#[expect(clippy::expect_used, reason = "simplify test failure output")]
-fn triggers_on_tags(world: &mut ReleaseWorld) {
-    let yaml = world.yaml.as_ref().expect("yaml parsed");
-    let on = yaml.get("on").expect("on");
-    let push = on.get("push").expect("push");
+fn triggers_on_tags(world: &mut ReleaseWorld) -> anyhow::Result<()> {
+    let yaml = world.yaml.as_ref().context("yaml parsed")?;
+    let on = yaml.get("on").context("on")?;
+    let push = on.get("push").context("push")?;
     let tags = push
         .get("tags")
-        .expect("tags")
+        .context("tags")?
         .as_sequence()
-        .expect("sequence");
-    let pattern = Regex::new(r"^v\*\.\*\.\*$").expect("compile regex");
+        .context("sequence")?;
+    let pattern = Regex::new(r"^v\*\.\*\.\*$").context("compile regex")?;
     assert!(
         tags.iter()
             .filter_map(|t| t.as_str())
             .any(|t| pattern.is_match(t)),
         "missing semantic version tag pattern",
     );
+    Ok(())
 }

--- a/tests/steps/worker_steps.rs
+++ b/tests/steps/worker_steps.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context as _;
 use comenq_lib::CommentRequest;
 use comenqd::config::Config;
 use comenqd::daemon::{WorkerControl, WorkerHooks, is_metadata_file, run_worker};
@@ -70,25 +71,22 @@ impl WorkerWorld {
 }
 
 #[given("a queued comment request")]
-#[expect(
-    clippy::expect_used,
-    reason = "test harness: fail fast on setup/IO errors"
-)]
-async fn queued_request(world: &mut WorkerWorld) {
-    let dir = TempDir::new().expect("tempdir");
+async fn queued_request(world: &mut WorkerWorld) -> anyhow::Result<()> {
+    let dir = TempDir::new().context("tempdir")?;
     let cfg = Arc::new(Config::from(temp_config(&dir).with_cooldown(0)));
-    let (mut sender, receiver) = channel(&cfg.queue_path).expect("channel");
+    let (mut sender, receiver) = channel(&cfg.queue_path).context("channel")?;
     let req = CommentRequest {
         owner: "o".into(),
         repo: "r".into(),
         pr_number: 1,
         body: "b".into(),
     };
-    let data = serde_json::to_vec(&req).expect("serialize");
-    sender.send(data).await.expect("send");
+    let data = serde_json::to_vec(&req).context("serialize")?;
+    sender.send(data).await.context("send")?;
     world.dir = Some(dir);
     world.cfg = Some(cfg);
     world.receiver = Some(receiver);
+    Ok(())
 }
 
 #[given("GitHub returns success")]
@@ -114,22 +112,22 @@ async fn github_error(world: &mut WorkerWorld) {
 }
 
 #[when("the worker runs briefly")]
-#[expect(
-    clippy::expect_used,
-    reason = "test harness: fail fast on world state errors"
-)]
-async fn worker_runs(world: &mut WorkerWorld) {
+async fn worker_runs(world: &mut WorkerWorld) -> anyhow::Result<()> {
     let cfg = world
         .cfg
         .as_ref()
-        .expect("configuration should be initialised")
+        .context("configuration should be initialised")?
         .clone();
     let rx = world
         .receiver
         .take()
-        .expect("receiver should be initialised");
-    let server = world.server.as_ref().expect("server should be initialised");
-    let octocrab = octocrab_for(server);
+        .context("receiver should be initialised")?;
+    let server = world
+        .server
+        .as_ref()
+        .context("server should be initialised")?;
+    let octocrab =
+        octocrab_for(server).context("octocrab client should build for the mock server")?;
     let (shutdown_tx, shutdown_rx) = watch::channel(());
     let idle = Arc::new(Notify::new());
     let idle_for_wait = Arc::clone(&idle);
@@ -150,45 +148,43 @@ async fn worker_runs(world: &mut WorkerWorld) {
         idle_notified,
     )
     .await
-    .expect("worker reached idle state within timeout");
+    .context("worker reached idle state within timeout")?;
 
     // Store handles in world for proper cleanup
     world.shutdown = Some(shutdown_tx);
     world.handle = Some(handle);
+    Ok(())
 }
 
 #[then("the comment is posted")]
-#[expect(
-    clippy::expect_used,
-    reason = "test harness: expect wiremock state in assertion"
-)]
-async fn comment_posted(world: &mut WorkerWorld) {
-    let server = world.server.as_ref().expect("server should be initialised");
+async fn comment_posted(world: &mut WorkerWorld) -> anyhow::Result<()> {
+    let server = world
+        .server
+        .as_ref()
+        .context("server should be initialised")?;
     assert!(
         !server
             .received_requests()
             .await
-            .expect("inbound requests should be recorded")
+            .context("inbound requests should be recorded")?
             .is_empty(),
     );
     world.shutdown_and_join().await;
+    Ok(())
 }
 
 #[then("the queue retains the job")]
-#[expect(
-    clippy::expect_used,
-    reason = "test harness: expect fs state in assertion"
-)]
-async fn queue_retains(world: &mut WorkerWorld) {
+async fn queue_retains(world: &mut WorkerWorld) -> anyhow::Result<()> {
     let cfg = world
         .cfg
         .as_ref()
-        .expect("configuration should be initialised");
+        .context("configuration should be initialised")?;
     let job_count = std::fs::read_dir(&cfg.queue_path)
-        .expect("queue directory should be readable")
+        .context("queue directory should be readable")?
         .filter_map(Result::ok)
         .filter(|e| !is_metadata_file(e.file_name()))
         .count();
     assert!(job_count > 0, "queue should retain at least one job file");
     world.shutdown_and_join().await;
+    Ok(())
 }


### PR DESCRIPTION
## Summary

This pull request adopts the Whitaker Dylint suite as part of the estate-wide rollout (see leynos/netsuke#410 for the reference adoption). The `lint` Makefile target now runs the suite after Clippy with warnings denied, and CI installs the pinned `whitaker-installer` (0.2.5) before linting, preferring `cargo binstall` with a `cargo install --locked` fallback and caching the installer binary keyed on its version. The release dry-run workflow is deliberately untouched so its required status checks keep their exact job names.

Adopting the suite surfaced findings that are fixed here in a preceding commit: the build scripts now propagate Cargo environment errors instead of calling `expect`; the daemon's backoff loops fall back to a non-panicking delay constant; `test-support::octocrab_for` is now fallible with a boxed error; and the cucumber step functions were converted to fallible steps returning `anyhow::Result`, with the harness building its Tokio runtime explicitly. Legitimately-ambient crates (build scripts, the daemon's socket and queue management, and the behavioural test crate's fixture I/O) are excluded from `no_std_fs_operations` in `dylint.toml`, each with a written rationale. Two small gate repairs ride along: markdownlint now ignores the vendored `vendor/` tree, and `nixie` is invoked without a literal glob argument.

## Review walkthrough

- [`Makefile`](https://github.com/leynos/comenq/blob/adopt-whitaker/Makefile) — `WHITAKER` tool variable, suite invocation in `lint`, and the nixie invocation fix.
- [`.github/workflows/ci.yml`](https://github.com/leynos/comenq/blob/adopt-whitaker/.github/workflows/ci.yml) — installer cache and hardened install step ahead of `make lint`.
- [`dylint.toml`](https://github.com/leynos/comenq/blob/adopt-whitaker/dylint.toml) — `no_std_fs_operations` exclusions with rationales.
- [`crates/comenqd/src/supervisor.rs`](https://github.com/leynos/comenq/blob/adopt-whitaker/crates/comenqd/src/supervisor.rs) and [`crates/comenqd/src/listener.rs`](https://github.com/leynos/comenq/blob/adopt-whitaker/crates/comenqd/src/listener.rs) — non-panicking backoff fallback.
- [`crates/comenq/build.rs`](https://github.com/leynos/comenq/blob/adopt-whitaker/crates/comenq/build.rs) and [`crates/comenqd/build.rs`](https://github.com/leynos/comenq/blob/adopt-whitaker/crates/comenqd/build.rs) — error propagation in the man-page staging.
- [`test-support/src/daemon.rs`](https://github.com/leynos/comenq/blob/adopt-whitaker/test-support/src/daemon.rs) — fallible `octocrab_for`.
- [`tests/steps/`](https://github.com/leynos/comenq/tree/adopt-whitaker/tests/steps) and [`tests/cucumber.rs`](https://github.com/leynos/comenq/blob/adopt-whitaker/tests/cucumber.rs) — fallible cucumber steps and explicit runtime construction.

## Validation

- `make check-fmt` — passed.
- `make lint` — passed (Clippy and the Whitaker suite, warnings denied).
- `make test` — passed (nextest 113/113; all cucumber features).
- `make markdownlint` — passed.
- `make nixie` — passed (all Mermaid diagrams validated).
