### PR TITLE
Stop pinning exact shared-actions commit SHAs in contract tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Comenq does not yet have a full developers' guide; this file collects the
+policies contributors need in the meantime. See
+[docs/comenq-design.md](docs/comenq-design.md) for the architecture and
+[docs/](docs/) for testing and library-rationale guides, and the "Building
+and testing" section of [README.md](README.md) for the `make` targets.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/test-support/src/workflow.rs
+++ b/test-support/src/workflow.rs
@@ -2,19 +2,6 @@
 
 use serde_yaml::Value;
 
-// Provide the shared-actions commit hash as a literal so concat! can build constants without runtime formatting.
-macro_rules! shared_actions_commit_literal {
-    () => {
-        "cb06757ebba47bb018ac0ade84fa5dc9ffb95020"
-    };
-}
-
-/// The commit hash for the shared-actions repository that the workflow must be pinned to.
-const SHARED_ACTIONS_COMMIT: &str = shared_actions_commit_literal!();
-
-/// The expected commit hash for the shared-actions repository.
-#[cfg(test)]
-const EXPECTED_SHARED_ACTIONS_COMMIT: &str = shared_actions_commit_literal!();
 /// The prefix for the shared release build composite action identifier.
 const RUST_BUILD_RELEASE_PREFIX: &str = "leynos/shared-actions/.github/actions/rust-build-release@";
 
@@ -22,22 +9,25 @@ const RUST_BUILD_RELEASE_PREFIX: &str = "leynos/shared-actions/.github/actions/r
 const UPLOAD_RELEASE_ASSETS_PREFIX: &str =
     "leynos/shared-actions/.github/actions/upload-release-assets@";
 
-/// The release builder action reference expected by tests, built at compile time to avoid allocations.
-#[cfg(test)]
-const EXPECTED_RUST_BUILDER: &str = concat!(
-    "leynos/shared-actions/.github/actions/rust-build-release@",
-    shared_actions_commit_literal!(),
-);
-
-/// The release publisher action reference expected by tests, built at compile time to avoid allocations.
-#[cfg(test)]
-const EXPECTED_UPLOAD_RELEASE_ASSETS: &str = concat!(
-    "leynos/shared-actions/.github/actions/upload-release-assets@",
-    shared_actions_commit_literal!(),
-);
+/// Return `true` when `commit` is a full 40-character lowercase hex commit SHA.
+///
+/// Dependabot owns the specific SHA value each `uses:` ref is pinned to, so
+/// this checks only the *shape* of the pin (a commit SHA, not a mutable
+/// branch or tag such as `main`), not which commit it names.
+fn is_forty_hex_commit_sha(commit: &str) -> bool {
+    commit.len() == 40
+        && commit
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
 
 /// Return `true` when the release workflow uses the shared composite actions to
-/// build binaries and publish packages.
+/// build binaries and publish packages, each pinned to a full commit SHA.
+///
+/// Dependabot bumps `rust-build-release` and `upload-release-assets`
+/// independently, so their pinned commits are not required to match one
+/// another — only that each is a genuine 40-hex commit SHA on the correct
+/// path.
 ///
 /// # Errors
 ///
@@ -64,13 +54,13 @@ pub fn uses_shared_release_actions(yaml: &str) -> Result<bool, serde_yaml::Error
             if let Some(uses) = step.get("uses").and_then(Value::as_str) {
                 if uses
                     .strip_prefix(RUST_BUILD_RELEASE_PREFIX)
-                    .is_some_and(|commit| commit == SHARED_ACTIONS_COMMIT)
+                    .is_some_and(is_forty_hex_commit_sha)
                 {
                     saw_rust_builder = true;
                 }
                 if uses
                     .strip_prefix(UPLOAD_RELEASE_ASSETS_PREFIX)
-                    .is_some_and(|commit| commit == SHARED_ACTIONS_COMMIT)
+                    .is_some_and(is_forty_hex_commit_sha)
                 {
                     saw_release_publisher = true;
                 }
@@ -83,25 +73,39 @@ pub fn uses_shared_release_actions(yaml: &str) -> Result<bool, serde_yaml::Error
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        EXPECTED_RUST_BUILDER, EXPECTED_SHARED_ACTIONS_COMMIT, EXPECTED_UPLOAD_RELEASE_ASSETS,
-        uses_shared_release_actions,
-    };
+    use super::uses_shared_release_actions;
     use rstest::rstest;
+
+    const RUST_BUILDER: &str = "leynos/shared-actions/.github/actions/rust-build-release@cb06757ebba47bb018ac0ade84fa5dc9ffb95020";
+    const UPLOAD_RELEASE_ASSETS: &str = "leynos/shared-actions/.github/actions/upload-release-assets@cb06757ebba47bb018ac0ade84fa5dc9ffb95020";
 
     #[test]
     #[expect(clippy::expect_used, reason = "simplify test output")]
     fn detects_shared_actions() {
-        assert!(EXPECTED_RUST_BUILDER.ends_with(EXPECTED_SHARED_ACTIONS_COMMIT));
-        assert!(EXPECTED_UPLOAD_RELEASE_ASSETS.ends_with(EXPECTED_SHARED_ACTIONS_COMMIT));
-
         let yaml = format!(
             r#"
         jobs:
           release:
             steps:
-              - uses: {EXPECTED_RUST_BUILDER}
-              - uses: {EXPECTED_UPLOAD_RELEASE_ASSETS}
+              - uses: {RUST_BUILDER}
+              - uses: {UPLOAD_RELEASE_ASSETS}
+        "#
+        );
+        assert!(uses_shared_release_actions(&yaml).expect("parse"));
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "simplify test output")]
+    fn independently_pinned_commits_are_accepted() {
+        // Dependabot bumps one action's pin at a time, so the two actions
+        // legitimately land on different commits between bumps.
+        let yaml = format!(
+            r#"
+        jobs:
+          release:
+            steps:
+              - uses: {RUST_BUILDER}
+              - uses: leynos/shared-actions/.github/actions/upload-release-assets@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
         "#
         );
         assert!(uses_shared_release_actions(&yaml).expect("parse"));
@@ -115,7 +119,7 @@ mod tests {
         jobs:
           release:
             steps:
-              - uses: {EXPECTED_UPLOAD_RELEASE_ASSETS}
+              - uses: {UPLOAD_RELEASE_ASSETS}
         "#
         );
         assert!(!uses_shared_release_actions(&yaml).expect("parse"));
@@ -129,28 +133,28 @@ mod tests {
         jobs:
           release:
             steps:
-              - uses: {EXPECTED_RUST_BUILDER}
+              - uses: {RUST_BUILDER}
         "#
         );
         assert!(!uses_shared_release_actions(&yaml).expect("parse"));
     }
 
     #[rstest]
-    #[case::mismatched_builder_commit(
-        "leynos/shared-actions/.github/actions/rust-build-release@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-        EXPECTED_UPLOAD_RELEASE_ASSETS
-    )]
     #[case::unpinned_builder(
         "leynos/shared-actions/.github/actions/rust-build-release@v1",
-        EXPECTED_UPLOAD_RELEASE_ASSETS
-    )]
-    #[case::mismatched_publisher_commit(
-        EXPECTED_RUST_BUILDER,
-        "leynos/shared-actions/.github/actions/upload-release-assets@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        UPLOAD_RELEASE_ASSETS
     )]
     #[case::unpinned_publisher(
-        EXPECTED_RUST_BUILDER,
+        RUST_BUILDER,
         "leynos/shared-actions/.github/actions/upload-release-assets@v1"
+    )]
+    #[case::short_builder_commit(
+        "leynos/shared-actions/.github/actions/rust-build-release@cb06757",
+        UPLOAD_RELEASE_ASSETS
+    )]
+    #[case::uppercase_publisher_commit(
+        RUST_BUILDER,
+        "leynos/shared-actions/.github/actions/upload-release-assets@CB06757EBBA47BB018AC0ADE84FA5DC9FFB95020"
     )]
     fn invalid_action_pinning_fails(#[case] builder: &str, #[case] publisher: &str) {
         let yaml = format!(

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -8,11 +8,17 @@ at a branch, widening permissions, or losing the workspace-wide test
 configuration) fails CI on the pull request rather than surfacing in a
 scheduled or manual run.
 
+The caller must reference the correct reusable workflow at a commit SHA;
+Dependabot owns the SHA value, so these tests assert the shape of the
+pin (the workflow path, and a full 40-hex commit SHA rather than a
+mutable branch or tag) without asserting which commit it names.
+
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,12 +27,8 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The leynos/shared-actions commit the caller pins. Bump the workflow
-#: and this constant together.
-PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: the root comenq-lib crate plus the
@@ -67,25 +69,19 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a 40-hex commit SHA.
+
+    Dependabot owns the SHA value, so this asserts the shape of the pin
+    (correct workflow path, full commit SHA rather than a mutable branch
+    or tag) without asserting which commit it names.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Dependabot already owns upgrades of `leynos/shared-actions` reusable
workflows and composite actions, but two contract tests pinned an exact
commit SHA and would fail on the very next Dependabot bump until a human
hand-edited the constant. This branch converts those exact-SHA assertions
into shape assertions: the caller must reference the correct
`leynos/shared-actions` path, pinned to a full 40-character lowercase hex
commit SHA (not a mutable branch or tag such as `main`), but the specific
SHA value is no longer checked. Dependabot now owns the SHA value outright.

- [tests/workflow_contracts/mutation_testing_test.py](https://github.com/leynos/comenq/blob/b253f826b9e27ce3d919b6c850fd0e7a0f590b92/tests/workflow_contracts/mutation_testing_test.py) — replaces the
  hard-coded `PINNED_SHA` constant and `EXPECTED_USES` equality check with a
  regex that matches the reusable workflow path plus a 40-hex SHA.
- [test-support/src/workflow.rs](https://github.com/leynos/comenq/blob/b253f826b9e27ce3d919b6c850fd0e7a0f590b92/test-support/src/workflow.rs) — backs the release-workflow behavioural
  test (`tests/steps/release_steps.rs`). Previously required
  `rust-build-release` and `upload-release-assets` to be pinned to the
  *same* SHA; that "single repo-wide pin" invariant is also a Dependabot
  blocker, since Dependabot bumps one `uses:` ref at a time. Now each
  action's pin is validated independently for shape (correct path, full
  40-hex commit SHA) without requiring the two to match.
- [CONTRIBUTING.md](https://github.com/leynos/comenq/blob/b253f826b9e27ce3d919b6c850fd0e7a0f590b92/CONTRIBUTING.md) (new) — the repository had no existing developers'
  guide, so this documents the workflow-pin policy in a minimal
  contributor-facing file.

No workflow file's actual pin changes; Dependabot continues to move those
SHAs forward as it always has.

`.github/dependabot.yml` already has a `github-actions` ecosystem entry
with `directory: "/"` and a weekly schedule, so no change was needed there.

## Review walkthrough

- Start with [tests/workflow_contracts/mutation_testing_test.py](https://github.com/leynos/comenq/blob/b253f826b9e27ce3d919b6c850fd0e7a0f590b92/tests/workflow_contracts/mutation_testing_test.py) to see the
  regex-based shape assertion replacing the exact-SHA check, and the
  updated module docstring.
- Then review [test-support/src/workflow.rs](https://github.com/leynos/comenq/blob/b253f826b9e27ce3d919b6c850fd0e7a0f590b92/test-support/src/workflow.rs) for the new
  `is_forty_hex_commit_sha` shape check and the removal of the
  cross-action equality requirement; the unit tests exercise both
  independently-pinned-but-different-SHA acceptance and unpinned/malformed
  rejection.
- Finish with [CONTRIBUTING.md](https://github.com/leynos/comenq/blob/b253f826b9e27ce3d919b6c850fd0e7a0f590b92/CONTRIBUTING.md) for the policy write-up.

## Validation

- `make test-workflow-contracts`: 6 passed
- `cargo test -p test-support`: 18 passed (including the new
  `independently_pinned_commits_are_accepted` case)
- `cargo test --test cucumber`: all scenarios pass, including the release
  feature, confirming the relaxed check still accepts today's `release.yml`
  (which currently pins `rust-build-release` and `upload-release-assets` to
  the same SHA, and `determine-release-modes`/`ensure-cargo-version` to a
  different one)
- `cargo clippy --workspace --all-targets --all-features`: clean
- `cargo fmt --check`: clean
- `make markdownlint`: clean
