### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@v7
       - name: Setup Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
             ~/.cache/cargo-binstall
           key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
       - name: Install Whitaker Dylint suite
+        env:
+          # The prebuilt dylint-link binary aborts its post-install
+          # verification when RUSTUP_TOOLCHAIN is unset, and the source
+          # fallback needs rustc >= 1.91, which the repository's pinned
+          # nightly predates. Run the installer on the runner's stable
+          # toolchain to satisfy both paths.
+          RUSTUP_TOOLCHAIN: stable
         run: |
           if ! command -v whitaker-installer >/dev/null 2>&1; then
             if cargo binstall --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Bumps the pinned `WHITAKER_INSTALLER_VERSION` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) from `0.2.5` to `0.2.6`.

## Why

The Whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer `0.2.5` provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that nightly, leaving the CI lint step red. `whitaker-installer` `0.2.6` provisions `cargo-dylint` 6.0.1 and its prebuilt dependency binaries are now published, so this pin unblocks CI.

## Test plan

- [ ] CI (including the Whitaker lint step) is green on this branch.
